### PR TITLE
Modularized output

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,12 @@
+steps:
+  - name: ":docker: Build"
+    plugins:
+      docker-compose#v2.5.1:
+        build:
+          - app
+
+  - name: ":node: Test"
+    command: "npm test"
+    plugins:
+      docker-compose#v2.5.1:
+        run: app

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,4 @@
 steps:
-  - name: ":docker: Build"
-    plugins:
-      docker-compose#v2.5.1:
-        build:
-          - app
-
   - name: ":node: Test"
     command: "npm test"
     plugins:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:10-alpine
+
+COPY . /usr/app
+WORKDIR /usr/app
+RUN npm install
+CMD [ "npm", "test" ]

--- a/bin/ecs-deployment-monitor
+++ b/bin/ecs-deployment-monitor
@@ -7,6 +7,7 @@ const moment = require('moment');
 const _ = require('lodash');
 const indent = require('indent');
 const monitor = require('../');
+const Renderer = require('../lib/renderer');
 
 const indentWidth = 4;
 
@@ -22,103 +23,6 @@ var deployment = monitor({
   failureThreshold: parseFloat(argv.failureThreshold),
 });
 
-var spinner = new clui.Spinner(' ');
-var startedAt = Date.now();
+deployment.on('error', (err) => { throw err } );
 
-var stateMap = {
-  'NotFound': {
-    'done': colors.red(`ECS Deployment for task definition "${deployment.options.taskDefinitionArn}" not found`),
-    'exitCode': 2
-  },
-  'Usurped': {
-    'done': colors.red(`A newer deployment is in progress, this deployment is no longer primary deployment`),
-    'exitCode': 3
-  },
-  'Created': {
-    'done': colors.gray('Deployment created'),
-    'waiting': 'Waiting for tasks to start',
-  },
-  'TasksStarted': {
-    'done': () => {
-      return colors.gray(`${deployment.tasksStarted.length} Tasks have started`);
-    },
-    'waiting': 'Waiting for new tasks to connect to the loadbalancer'
-  },
-  'TasksFailed': {
-    'done': () => {
-      return colors.red(`${deployment.tasksFailed.length} Tasks have failed`);
-    },
-    'extra': () => {
-      let str = "\nFailure Reasons\n";
-      _.each(deployment.tasksFailedFull, (task) => {
-        str += `\nTask: ${task.taskArn}\nReason: ${task.stoppedReason}\n`
-      });
-      return colors.red(str);
-    },
-    'exitCode': 1
-  },
-  'Live': {
-    'done': colors.gray('All tasks are live and serving requests'),
-    'waiting': 'Waiting for old tasks to disconnect from the loadbalancer'
-  },
-  'Draining': {
-    'done': colors.gray('Old tasks are no longer serving new requests from the loadbalancer'),
-    'waiting': 'Waiting for active requests to old tasks to drain'
-  },
-  'Steady': {
-    'done': colors.green('Deployment was successful'),
-    'exitCode': 0
-  }
-}
-
-deployment.on('error', (err) => {
-  throw err;
-});
-
-deployment.on('state', (state) => {
-  var stateInfo = stateMap[state];
-  var durationSeconds = (Date.now() - startedAt)/1000;
-  var duration = moment.duration(durationSeconds, 'seconds');
-  var durationText = `${duration.seconds()} seconds`;
-
-  if (duration.minutes()) {
-    durationText = `${duration.minutes()} minutes ${durationText}`
-  }
-
-  if (duration.hours()) {
-    durationText = `${duration.hours()} hours ${durationText}`
-  }
-
-  durationText = colors.gray(`(${durationText})`);
-
-  spinner.stop();
-  console.log(colors.cyan(`-> ${state}`)+` ${durationText}`);
-
-  // Display done message
-  var doneMsg = stateInfo.done;
-  if (typeof doneMsg === "function") {
-    doneMsg = doneMsg();
-  }
-
-  console.log(indent(doneMsg, indentWidth));
-
-  // Display waiting message
-  if (stateInfo.waiting) {
-    spinner.message(stateInfo.waiting);
-    spinner.start();
-  }
-
-  var extraMsg = stateInfo.extra;
-  if (typeof extraMsg === "function") {
-    extraMsg = extraMsg();
-  }
-
-  if (extraMsg && extraMsg.length > 0) {
-    console.log(indent(extraMsg, indentWidth));
-  }
-
-  // Exit if needed
-  if (stateInfo.exitCode) {
-    process.exit(stateInfo.exitCode);
-  }
-});
+Renderer.watch(deployment, process.stdout);

--- a/bin/ecs-deployment-monitor
+++ b/bin/ecs-deployment-monitor
@@ -1,15 +1,7 @@
 #!/usr/bin/env node
 'use strict'
 
-const colors = require('colors/safe');
-const clui = require('clui');
-const moment = require('moment');
-const _ = require('lodash');
-const indent = require('indent');
 const monitor = require('../');
-const Renderer = require('../lib/renderer');
-
-const indentWidth = 4;
 
 var argv = require('yargs')
   .demand([ 'cluster', 'service-name', 'task-definition' ])
@@ -21,8 +13,8 @@ var deployment = monitor({
   clusterArn: argv.cluster,
   taskDefinitionArn: argv.taskDefinition,
   failureThreshold: parseFloat(argv.failureThreshold),
+  outputStream: process.stdout
 });
 
-deployment.on('error', (err) => { throw err } );
-
-Renderer.watch(deployment, process.stdout);
+deployment.on('error', (err) => { throw err });
+deployment.on('exitCode', (exitCode) => process.exit(exitCode));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+version: '3'
+services:
+  app:
+    build: .

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 
 const Service = require('./lib/service');
 const Deployment = require('./lib/deployment');
+const Renderer = require('./lib/renderer');
 
 module.exports = function(options) {
   _.defaults(options, {
@@ -26,13 +27,17 @@ module.exports = function(options) {
   let deployment = new Deployment({
     taskDefinitionArn: options.taskDefinitionArn,
     failureThreshold: options.failureThreshold,
-    service: service
+    service: service,
   });
 
   deployment.on('end', (state) => {
     service.destroy();
     deployment.destroy();
   });
+
+  if (options.outputStream) {
+    Renderer.watch(deployment, options.outputStream);
+  }
 
   return deployment;
 }

--- a/lib/renderer/index.js
+++ b/lib/renderer/index.js
@@ -116,13 +116,13 @@ const Renderer = {
    * @param {string} state The state change
    */
   _stateChange(deployment, output, state) {
-    // Finish Renderer of last state
+    // Finish render of last state
     Renderer._removeWaitingMessage(output);
     if (Renderer._getStateStartedAt()) {
       output.write(indent(colors.gray(`Step took ${Renderer._getStateDurationText()} to complete`), indentWidth)+"\n");
     }
 
-    // Renderer new State
+    // Render new State
     let stateInfo = states[state](deployment);
     Renderer._setStateStartedAt(Date.now());
     output.write(colors.cyan(`-> ${state}\n`));

--- a/lib/renderer/index.js
+++ b/lib/renderer/index.js
@@ -22,10 +22,9 @@ const Renderer = {
    * @param {object} deployment A task object
    * @param {stream} output A stream. If process.stdout then tty is assumed and
    *   it will be sent decorative output
-   * @param {function} cb A callback which will be triggered once finished
    */
-  watch(deployment, output, cb) {
-    deployment.on('state', (state) => Renderer._stateChange(deployment, output, state, cb));
+  watch(deployment, output) {
+    deployment.on('state', (state) => Renderer._stateChange(deployment, output, state));
     Renderer._setDeployStartedAt(Date.now());
   },
 
@@ -115,9 +114,8 @@ const Renderer = {
    * @param {object} deployment A task object
    * @param {stream} output A stream
    * @param {string} state The state change
-   * @param {function} cb A callback which will be called once deployment is finished
    */
-  _stateChange(deployment, output, state, cb) {
+  _stateChange(deployment, output, state) {
     // Finish Renderer of last state
     Renderer._removeWaitingMessage(output);
     if (Renderer._getStateStartedAt()) {

--- a/lib/renderer/index.js
+++ b/lib/renderer/index.js
@@ -125,10 +125,15 @@ const Renderer = {
     }
 
     // Renderer new State
-    var stateInfo = states[state](deployment);
+    let stateInfo = states[state](deployment);
     Renderer._setStateStartedAt(Date.now());
     output.write(colors.cyan(`-> ${state}\n`));
-    output.write(indent(stateInfo.done, indentWidth)+"\n");
+
+    let outputColor = 'gray';
+    if (deployment.isSteady()) outputColor = 'green';
+    if (deployment.isFailure()) outputColor = 'red';
+
+    output.write(indent(colors[outputColor](stateInfo.done), indentWidth)+"\n");
 
     // Display waiting message
     if (stateInfo.waiting) {
@@ -136,10 +141,10 @@ const Renderer = {
     }
 
     if (stateInfo.extra && stateInfo.extra.length > 0) {
-      output.write(indent(stateInfo.extra, indentWidth)+"\n");
+      output.write(indent(colors[outputColor](stateInfo.extra), indentWidth)+"\n");
     }
 
-    if (stateInfo.exitCode) {
+    if (stateInfo.exitCode !== undefined) {
       deployment.emit('exitCode', stateInfo.exitCode? stateInfo.exitCode : 0)
     }
   }

--- a/lib/renderer/index.js
+++ b/lib/renderer/index.js
@@ -1,0 +1,148 @@
+'use static'
+
+const readline = require('readline');
+
+const moment = require('moment');
+const colors = require('colors/safe');
+const indent = require('indent');
+
+const states = require('./states');
+const indentWidth = 4;
+
+var _deployStartedAt;
+var _stateStartedAt;
+var _spinner;
+
+const Renderer = {
+  /**
+   * watch
+   *
+   * Watch a deployment and render information about state changes to output stream.
+   *
+   * @param {object} deployment A task object
+   * @param {stream} output A stream. If process.stdout then tty is assumed and
+   *   it will be sent decorative output
+   * @param {function} cb A callback which will be triggered once finished
+   */
+  watch(deployment, output, cb) {
+    deployment.on('state', (state) => Renderer._stateChange(deployment, output, state, cb));
+    Renderer._setDeployStartedAt(Date.now());
+  },
+
+  _setDeployStartedAt(date) {
+    _deployStartedAt = date;
+  },
+
+  _setStateStartedAt(date) {
+    _stateStartedAt = date;
+  },
+
+  _getStateStartedAt(date) {
+    return _stateStartedAt;
+  },
+
+  _getStateDuraton() {
+    return (Date.now() - Renderer._getStateStartedAt())/1000;
+  },
+
+  /**
+   * _getStateDurationText
+   *
+   * Get the duration the current state has been in progress for in
+   * descriptive text form.
+   *
+   * @return {string}
+   */
+  _getStateDurationText() {
+    let durationSeconds = Renderer._getStateDuraton();
+    let duration = moment.duration(durationSeconds, 'seconds');
+    let durationText = `${duration.seconds()} seconds`;
+
+    if (duration.minutes()) {
+      durationText = `${duration.minutes()} minutes ${durationText}`
+    }
+
+    if (duration.hours()) {
+      durationText = `${duration.hours()} hours ${durationText}`
+    }
+
+    return durationText;
+  },
+
+  /**
+   * _showWaitingMessage
+   *
+   * Show a temporary waiting message while state is in progress.
+   *
+   * @param {stream} output A stream
+   */
+  _showWaitingMessage(output, msg) {
+    // Only shown if output is a tty (process.stdout).
+    if (!(output instanceof require('tty').WriteStream)) return;
+
+    let spinnerSymbols = ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'];
+    let i = 0;
+    _spinner = setInterval(function() {
+      readline.clearLine(output);
+      readline.cursorTo(output, indentWidth-2);
+      output.write(colors.cyan(spinnerSymbols[i]));
+      output.write(' '+colors.gray(msg));
+
+      // Increase the counter until it reaches the end of the array
+      if (i >= (spinnerSymbols.length - 1)) i = 0;
+      else i++;
+    }, 1000);
+  },
+
+  /**
+   * _removeWaitingMessage
+   *
+   * Remove the waiting message
+   *
+   * @param {stream} output A stream
+   */
+  _removeWaitingMessage(output) {
+    clearInterval(_spinner);
+    readline.clearLine(output);
+    readline.cursorTo(output, 0);
+  },
+
+  /**
+   * _stateChange
+   *
+   * Process a state change on a deployment
+   *
+   * @param {object} deployment A task object
+   * @param {stream} output A stream
+   * @param {string} state The state change
+   * @param {function} cb A callback which will be called once deployment is finished
+   */
+  _stateChange(deployment, output, state, cb) {
+    // Finish Renderer of last state
+    Renderer._removeWaitingMessage(output);
+    if (Renderer._getStateStartedAt()) {
+      output.write(indent(colors.gray(`Step took ${Renderer._getStateDurationText()} to complete`), indentWidth)+"\n");
+    }
+
+    // Renderer new State
+    var stateInfo = states[state](deployment);
+    Renderer._setStateStartedAt(Date.now());
+    output.write(colors.cyan(`-> ${state}\n`));
+    output.write(indent(stateInfo.done, indentWidth)+"\n");
+
+    // Display waiting message
+    if (stateInfo.waiting) {
+      Renderer._showWaitingMessage(output, stateInfo.waiting);
+    }
+
+    if (stateInfo.extra && stateInfo.extra.length > 0) {
+      output.write(indent(stateInfo.extra, indentWidth)+"\n");
+    }
+
+    if (stateInfo.exitCode) {
+      process.exit(stateInfo.exitCode);
+    }
+  }
+}
+
+module.exports = Renderer;

--- a/lib/renderer/index.js
+++ b/lib/renderer/index.js
@@ -84,12 +84,9 @@ const Renderer = {
     _spinner = setInterval(function() {
       readline.clearLine(output);
       readline.cursorTo(output, indentWidth-2);
-      output.write(colors.cyan(spinnerSymbols[i]));
+      output.write(colors.cyan(spinnerSymbols[i%spinnerSymbols.length]));
       output.write(' '+colors.gray(msg));
-
-      // Increase the counter until it reaches the end of the array
-      if (i >= (spinnerSymbols.length - 1)) i = 0;
-      else i++;
+      i++;
     }, 1000);
   },
 

--- a/lib/renderer/index.js
+++ b/lib/renderer/index.js
@@ -140,7 +140,7 @@ const Renderer = {
     }
 
     if (stateInfo.exitCode) {
-      process.exit(stateInfo.exitCode);
+      deployment.emit('exitCode', stateInfo.exitCode? stateInfo.exitCode : 0)
     }
   }
 }

--- a/lib/renderer/states/created.js
+++ b/lib/renderer/states/created.js
@@ -4,7 +4,7 @@ const colors = require('colors/safe');
 
 module.exports = function(deployment) {
   return {
-    'done': colors.gray('Deployment created'),
+    'done': 'Deployment created',
     'waiting': 'Waiting for tasks to start',
   }
 }

--- a/lib/renderer/states/created.js
+++ b/lib/renderer/states/created.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const colors = require('colors/safe');
+
+module.exports = function(deployment) {
+  return {
+    'done': colors.gray('Deployment created'),
+    'waiting': 'Waiting for tasks to start',
+  }
+}

--- a/lib/renderer/states/draining.js
+++ b/lib/renderer/states/draining.js
@@ -4,7 +4,7 @@ const colors = require('colors/safe');
 
 module.exports = function(deployment) {
   return {
-    'done': colors.gray('Old tasks are no longer serving new requests from the loadbalancer'),
+    'done': 'Old tasks are no longer serving new requests from the loadbalancer',
     'waiting': 'Waiting for active requests to old tasks to drain'
   }
 }

--- a/lib/renderer/states/draining.js
+++ b/lib/renderer/states/draining.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const colors = require('colors/safe');
+
+module.exports = function(deployment) {
+  return {
+    'done': colors.gray('Old tasks are no longer serving new requests from the loadbalancer'),
+    'waiting': 'Waiting for active requests to old tasks to drain'
+  }
+}

--- a/lib/renderer/states/index.js
+++ b/lib/renderer/states/index.js
@@ -1,0 +1,1 @@
+module.exports = require('requirize')(__dirname, 'classify');

--- a/lib/renderer/states/live.js
+++ b/lib/renderer/states/live.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const colors = require('colors/safe');
+
+module.exports = function(deployment) {
+  return {
+    'done': colors.gray('All tasks are live and serving requests'),
+    'waiting': 'Waiting for old tasks to disconnect from the loadbalancer'
+  }
+}

--- a/lib/renderer/states/live.js
+++ b/lib/renderer/states/live.js
@@ -4,7 +4,7 @@ const colors = require('colors/safe');
 
 module.exports = function(deployment) {
   return {
-    'done': colors.gray('All tasks are live and serving requests'),
+    'done': 'All tasks are live and serving requests',
     'waiting': 'Waiting for old tasks to disconnect from the loadbalancer'
   }
 }

--- a/lib/renderer/states/not-found.js
+++ b/lib/renderer/states/not-found.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const colors = require('colors/safe');
+
+module.exports = function(deployment) {
+  return {
+    'done': colors.red(`ECS Deployment for task definition "${deployment.options.taskDefinitionArn}" not found`),
+    'exitCode': 2
+  }
+}

--- a/lib/renderer/states/not-found.js
+++ b/lib/renderer/states/not-found.js
@@ -4,7 +4,7 @@ const colors = require('colors/safe');
 
 module.exports = function(deployment) {
   return {
-    'done': colors.red(`ECS Deployment for task definition "${deployment.options.taskDefinitionArn}" not found`),
+    'done': `ECS Deployment for task definition "${deployment.options.taskDefinitionArn}" not found`,
     'exitCode': 2
   }
 }

--- a/lib/renderer/states/steady.js
+++ b/lib/renderer/states/steady.js
@@ -4,7 +4,7 @@ const colors = require('colors/safe');
 
 module.exports = function(deployment) {
   return {
-    'done': colors.green('Deployment was successful'),
+    'done': 'Deployment was successful',
     'exitCode': 0
   }
 }

--- a/lib/renderer/states/steady.js
+++ b/lib/renderer/states/steady.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const colors = require('colors/safe');
+
+module.exports = function(deployment) {
+  return {
+    'done': colors.green('Deployment was successful'),
+    'exitCode': 0
+  }
+}

--- a/lib/renderer/states/tasks-failed.js
+++ b/lib/renderer/states/tasks-failed.js
@@ -10,8 +10,8 @@ module.exports = function(deployment) {
   });
 
   return {
-    'done': colors.red(`${deployment.tasksFailed.length} Tasks have failed`),
-    'extra': colors.red(extraMsg),
+    'done': `${deployment.tasksFailed.length} Tasks have failed`,
+    'extra': extraMsg,
     'exitCode': 1
   }
 }

--- a/lib/renderer/states/tasks-failed.js
+++ b/lib/renderer/states/tasks-failed.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const _ = require('lodash');
+const colors = require('colors/safe');
+
+module.exports = function(deployment) {
+  let extraMsg = "\nFailure Reasons\n";
+  _.each(deployment.tasksFailedFull, (task) => {
+    extraMsg += `\nTask: ${task.taskArn}\nReason: ${task.stoppedReason}\n`
+  });
+
+  return {
+    'done': colors.red(`${deployment.tasksFailed.length} Tasks have failed`),
+    'extra': colors.red(extraMsg),
+    'exitCode': 1
+  }
+}

--- a/lib/renderer/states/tasks-started.js
+++ b/lib/renderer/states/tasks-started.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const colors = require('colors/safe');
+
+module.exports = function(deployment) {
+  return {
+    'done': colors.gray(`${deployment.tasksStarted.length} Tasks have started`),
+    'waiting': 'Waiting for new tasks to connect to the loadbalancer'
+  }
+}

--- a/lib/renderer/states/tasks-started.js
+++ b/lib/renderer/states/tasks-started.js
@@ -4,7 +4,7 @@ const colors = require('colors/safe');
 
 module.exports = function(deployment) {
   return {
-    'done': colors.gray(`${deployment.tasksStarted.length} Tasks have started`),
+    'done': `${deployment.tasksStarted.length} Tasks have started`,
     'waiting': 'Waiting for new tasks to connect to the loadbalancer'
   }
 }

--- a/lib/renderer/states/usurped.js
+++ b/lib/renderer/states/usurped.js
@@ -4,7 +4,7 @@ const colors = require('colors/safe');
 
 module.exports = function(deployment) {
   return {
-    'done': colors.red(`A newer deployment is in progress, this deployment is no longer primary deployment`),
+    'done': 'A newer deployment is in progress, this deployment is no longer primary deployment',
     'exitCode': 3
   }
 }

--- a/lib/renderer/states/usurped.js
+++ b/lib/renderer/states/usurped.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const colors = require('colors/safe');
+
+module.exports = function(deployment) {
+  return {
+    'done': colors.red(`A newer deployment is in progress, this deployment is no longer primary deployment`),
+    'exitCode': 3
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -840,6 +840,12 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
+    "stream-buffers": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
+      "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==",
+      "dev": true
+    },
     "supports-color": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecs-deployment-monitor",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -866,6 +866,12 @@
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
       "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM="
     },
+    "timekeeper": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.1.2.tgz",
+      "integrity": "sha512-fc1DDqbiyz5vxRO4xkiATwfWUw1FV7W20+FJYal1SnoIYgNuB4WNxYLtbG3zjUBwOSk3P4u1TgBAZYG/aqBWMw==",
+      "dev": true
+    },
     "timers-ext": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,172 +4,131 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "samsam": "1.3.0"
+      },
+      "dependencies": {
+        "samsam": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+          "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
+      "integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg==",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "requires": {
+        "lodash": "4.17.10"
       }
     },
     "aws-sdk": {
-      "version": "2.112.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.112.0.tgz",
-      "integrity": "sha1-mgSMDdWnQHoh9uhiNx0gSanPs1A=",
+      "version": "2.282.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.282.1.tgz",
+      "integrity": "sha512-2/QFnzANnU/Fy4hdCz93bq8ERG2gANfGytt4cZGEPC0V6ePx22JqYGZMYUmBEGsWDCKbKc8l8QZDDer4r/0QBw==",
       "requires": {
         "buffer": "4.9.1",
-        "crypto-browserify": "1.0.9",
         "events": "1.1.1",
+        "ieee754": "1.1.8",
         "jmespath": "0.15.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
-        "uuid": "3.0.1",
-        "xml2js": "0.4.17",
-        "xmlbuilder": "4.2.1"
-      },
-      "dependencies": {
-        "base64-js": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-          "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
-        },
-        "buffer": {
-          "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-          "requires": {
-            "base64-js": "1.2.1",
-            "ieee754": "1.1.8",
-            "isarray": "1.0.0"
-          }
-        },
-        "crypto-browserify": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
-          "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA="
-        },
-        "ieee754": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "jmespath": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-          "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-        },
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-        },
-        "querystring": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-          "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-        },
-        "sax": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
-        },
-        "url": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-          "requires": {
-            "punycode": "1.3.2",
-            "querystring": "0.2.0"
-          }
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
-        },
-        "xml2js": {
-          "version": "0.4.17",
-          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-          "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
-          "requires": {
-            "sax": "1.2.1",
-            "xmlbuilder": "4.2.1"
-          }
-        },
-        "xmlbuilder": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-          "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        }
+        "uuid": "3.1.0",
+        "xml2js": "0.4.19"
       }
     },
     "aws-sdk-mock": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-1.7.0.tgz",
-      "integrity": "sha1-dpizuoL0k/cf8GCuISPNCAathnY=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-4.0.0.tgz",
+      "integrity": "sha512-wW79xLFuinT4pXVCql3sokddHGaEyG7sM8rCV5CTmaemxG/w2T0dN9Z6mAg5J2ZnnJLa8kkO2lg7ltd6U05ihA==",
       "dev": true,
       "requires": {
-        "aws-sdk": "2.112.0",
-        "sinon": "1.17.7",
+        "aws-sdk": "2.282.1",
+        "sinon": "6.1.4",
         "traverse": "0.6.6"
       },
       "dependencies": {
-        "formatio": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-          "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-          "dev": true,
-          "requires": {
-            "samsam": "1.1.2"
-          }
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "just-extend": {
+          "version": "1.1.27",
+          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+          "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+          "dev": true
         },
         "lolex": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-          "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz",
+          "integrity": "sha512-Oo2Si3RMKV3+lV5MsSWplDQFoTClz/24S0MMHYcgGWWmFXr6TMlqcqk/l1GtH+d5wLBwNRiqGnwDRMirtFalJw==",
           "dev": true
         },
-        "samsam": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-          "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
-          "dev": true
+        "nise": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
+          "integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/formatio": "2.0.0",
+            "just-extend": "1.1.27",
+            "lolex": "2.7.1",
+            "path-to-regexp": "1.7.0",
+            "text-encoding": "0.6.4"
+          }
         },
         "sinon": {
-          "version": "1.17.7",
-          "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-          "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.1.4.tgz",
+          "integrity": "sha512-NFEts+4D4jp2sBjL94fQpZk5o73kzn/g58+I9Dp15i9vsnT4Lk1UEyUf2jACODWLG6Pz/llF0sArYUw47Aarmg==",
           "dev": true,
           "requires": {
-            "formatio": "1.1.1",
-            "lolex": "1.3.2",
-            "samsam": "1.1.2",
-            "util": "0.10.3"
+            "@sinonjs/formatio": "2.0.0",
+            "@sinonjs/samsam": "2.0.0",
+            "diff": "3.5.0",
+            "lodash.get": "4.4.2",
+            "lolex": "2.7.1",
+            "nise": "1.4.2",
+            "supports-color": "5.4.0",
+            "type-detect": "4.0.8"
           }
         },
-        "traverse": {
-          "version": "0.6.6",
-          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-          "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
           "dev": true
-        },
-        "util": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.1"
-          }
         }
       }
     },
@@ -178,6 +137,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -194,6 +158,23 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
+      }
     },
     "cli-color": {
       "version": "0.3.2",
@@ -215,36 +196,40 @@
       }
     },
     "color": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
-      "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
       "requires": {
-        "color-convert": "0.5.3",
-        "color-string": "0.3.0"
+        "color-convert": "1.9.2",
+        "color-string": "1.5.2"
       }
     },
     "color-convert": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-      "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "requires": {
+        "color-name": "1.1.1"
+      }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
     },
     "color-string": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+      "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "1.1.1",
+        "simple-swizzle": "0.2.2"
       }
     },
     "colornames": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
-      "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
     },
     "colors": {
       "version": "1.1.2",
@@ -252,12 +237,12 @@
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "colorspace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
-      "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.1.tgz",
+      "integrity": "sha512-pI3btWyiuz7Ken0BWh9Elzsmv2bM9AhA7psXib4anUXy/orfZ/E0MbQwhSOG/9L8hLlalqrU0UhOuqxW1YjmVw==",
       "requires": {
-        "color": "0.8.0",
-        "text-hex": "0.0.0"
+        "color": "3.0.0",
+        "text-hex": "1.0.0"
       }
     },
     "commander": {
@@ -275,6 +260,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
     "d": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
@@ -282,11 +272,6 @@
       "requires": {
         "es5-ext": "0.10.30"
       }
-    },
-    "date-fns": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
     },
     "debug": {
       "version": "2.6.8",
@@ -298,13 +283,13 @@
       }
     },
     "diagnostics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.0.tgz",
-      "integrity": "sha1-4QkJALSVI+hSe+IPCBJ1IF8q42o=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
       "requires": {
-        "colorspace": "1.0.1",
+        "colorspace": "1.1.1",
         "enabled": "1.0.2",
-        "kuler": "0.0.0"
+        "kuler": "1.0.0"
       }
     },
     "diff": {
@@ -318,13 +303,13 @@
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
-        "env-variable": "0.0.3"
+        "env-variable": "0.0.4"
       }
     },
     "env-variable": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz",
-      "integrity": "sha1-uGwWQb5WECZ9UG8YBx6nbXBwl8s="
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.4.tgz",
+      "integrity": "sha512-+jpGxSWG4vr6gVxUHOc4p+ilPnql7NzZxOZBxNldsKGjCF+97df3CbuX7XMaDa5oAVkKQj4rKp38rYdC4VcpDg=="
     },
     "es5-ext": {
       "version": "0.10.30",
@@ -442,6 +427,16 @@
       "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.4.tgz",
+      "integrity": "sha512-mNlGUdKOeGNleyrmgbKYtbnCr9KZkZXU7eM89JRo8vY10f7Ul1Fbj07hUBW3N4fC0xM+fmfFfa2zM7mIizhpNQ=="
+    },
+    "fecha": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
+    },
     "formatio": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
@@ -489,6 +484,11 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    },
     "indent": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/indent/-/indent-0.0.2.tgz",
@@ -520,16 +520,21 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "json3": {
       "version": "3.3.2",
@@ -544,17 +549,17 @@
       "dev": true
     },
     "kuler": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
-      "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.0.tgz",
+      "integrity": "sha512-oyy6pu/yWRjiVfCoJebNUKFL061sNtrs9ejKTbirIwY3oiHmENVCSkHhxDV85Dkm7JYR/czMCBeoM87WilTdSg==",
       "requires": {
-        "colornames": "0.0.2"
+        "colornames": "1.1.1"
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -601,6 +606,12 @@
         "lodash._isiterateecall": "3.0.9"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -625,12 +636,27 @@
       }
     },
     "logform": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-1.2.1.tgz",
-      "integrity": "sha1-5wfvez86nxbCSK5X8dAVB0/Ga/U=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-1.9.1.tgz",
+      "integrity": "sha512-ZHrZE8VSf7K3xKxJiQ1aoTBp2yK+cEbFcgarsjzI3nt3nE/3O0heNSppoOQMUJVMZo/xiVwCxiXIabaZApsKNQ==",
       "requires": {
-        "colors": "1.1.2",
-        "date-fns": "1.29.0"
+        "colors": "1.3.1",
+        "fast-safe-stringify": "2.0.4",
+        "fecha": "2.3.3",
+        "ms": "2.1.1",
+        "triple-beam": "1.3.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
+          "integrity": "sha512-jg/vxRmv430jixZrC+La5kMbUWqIg32/JsYNZb94+JEmzceYbWKTsv1OuTp+7EaqiaWRR2tPcykibwCRgclIsw=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "lolex": {
@@ -713,9 +739,9 @@
       }
     },
     "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "ms": {
       "version": "2.0.0",
@@ -783,6 +809,47 @@
         "isarray": "0.0.1"
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
+      }
+    },
     "requirize": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/requirize/-/requirize-0.1.3.tgz",
@@ -812,11 +879,36 @@
         }
       }
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "samsam": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
       "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
       "dev": true
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "0.3.2"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
     },
     "sinon": {
       "version": "3.2.1",
@@ -846,6 +938,14 @@
       "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "supports-color": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
@@ -862,9 +962,9 @@
       "dev": true
     },
     "text-hex": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
-      "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
     "timekeeper": {
       "version": "2.1.2",
@@ -888,10 +988,16 @@
         }
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
     "triple-beam": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.1.0.tgz",
-      "integrity": "sha1-KsOHyMS9BL0mxh34kaYHn4WS/hA="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "type-detect": {
       "version": "4.0.3",
@@ -899,38 +1005,69 @@
       "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
       "dev": true
     },
-    "winston": {
-      "version": "3.0.0-rc1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.0.0-rc1.tgz",
-      "integrity": "sha512-aNtKirnK2UEe5v56SK0TIEr5ylyYdXyjAaIJXZTk21UlNx7FQclTkVU2T1ZzMtdDM+Rk2b7vrI/e/4n8U84XaQ==",
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
       "requires": {
-        "async": "1.5.2",
-        "diagnostics": "1.1.0",
-        "isstream": "0.1.2",
-        "logform": "1.2.1",
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
+    "winston": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.0.0.tgz",
+      "integrity": "sha512-7QyfOo1PM5zGL6qma6NIeQQMh71FBg/8fhkSAePqtf5YEi6t+UrPDcUuHhuuUasgso49ccvMEsmqr0GBG2qaMQ==",
+      "requires": {
+        "async": "2.6.1",
+        "diagnostics": "1.1.1",
+        "is-stream": "1.1.0",
+        "logform": "1.9.1",
         "one-time": "0.0.4",
+        "readable-stream": "2.3.6",
         "stack-trace": "0.0.10",
-        "triple-beam": "1.1.0",
-        "winston-transport": "3.0.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        }
+        "triple-beam": "1.3.0",
+        "winston-transport": "4.2.0"
       }
     },
     "winston-transport": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-3.0.1.tgz",
-      "integrity": "sha1-gAixXu9WYMT7P6CU1YzL0IUoxY0="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.2.0.tgz",
+      "integrity": "sha512-0R1bvFqxSlK/ZKTH86nymOuKv/cT1PQBMuDdA7k7f0S9fM44dNH6bXnuxwXPrN8lefJgtZq08BKdyZ0DZIy/rg==",
+      "requires": {
+        "readable-stream": "2.3.6",
+        "triple-beam": "1.3.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.1",
+        "xmlbuilder": "9.0.7"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "yargs": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Coen Hyde",
   "license": "MIT",
   "devDependencies": {
-    "aws-sdk-mock": "^1.7.0",
+    "aws-sdk-mock": "^4.0.0",
     "expect.js": "^0.3.1",
     "mocha": "^3.5.0",
     "sinon": "^3.2.1",
@@ -20,16 +20,16 @@
     "timekeeper": "^2.1.2"
   },
   "dependencies": {
-    "async": "^2.4.1",
-    "aws-sdk": "^2.49.0",
+    "async": "^2.6.1",
+    "aws-sdk": "^2.282.1",
     "clui": "^0.3.6",
     "colors": "^1.1.2",
     "indent": "0.0.2",
     "inflection": "^1.12.0",
-    "lodash": "^4.17.4",
-    "moment": "^2.18.1",
+    "lodash": "^4.17.10",
+    "moment": "^2.22.2",
     "requirize": "^0.1.3",
-    "winston": "^3.0.0-rc0",
+    "winston": "^3.0.0",
     "yargs": "^7.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "aws-sdk-mock": "^1.7.0",
     "expect.js": "^0.3.1",
     "mocha": "^3.5.0",
-    "sinon": "^3.2.1"
+    "sinon": "^3.2.1",
+    "stream-buffers": "^3.0.2"
   },
   "dependencies": {
     "async": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "expect.js": "^0.3.1",
     "mocha": "^3.5.0",
     "sinon": "^3.2.1",
-    "stream-buffers": "^3.0.2"
+    "stream-buffers": "^3.0.2",
+    "timekeeper": "^2.1.2"
   },
   "dependencies": {
     "async": "^2.4.1",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -2,10 +2,11 @@
 
 const path = require('path');
 const AWS = require('aws-sdk-mock');
+const AWSSDK = require('aws-sdk');
 
 // Set the default region to 'us-east-1' if not already set
-if (!AWS.config.region) {
-  AWS.config.update({
+if (!AWSSDK.config.region) {
+  AWSSDK.config.update({
     region: process.env.AWS_DEFAULT_REGION || 'us-east-1'
   });
 }
@@ -13,5 +14,5 @@ if (!AWS.config.region) {
 AWS.setSDK(path.resolve('node_modules/aws-sdk'));
 
 module.exports = {
-  afterEach: () => AWS.restore();
+  afterEach: () => AWS.restore()
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,8 +3,15 @@
 const path = require('path');
 const AWS = require('aws-sdk-mock');
 
+// Set the default region to 'us-east-1' if not already set
+if (!AWS.config.region) {
+  AWS.config.update({
+    region: process.env.AWS_DEFAULT_REGION || 'us-east-1'
+  });
+}
+
 AWS.setSDK(path.resolve('node_modules/aws-sdk'));
 
 module.exports = {
-  afterEach: () => AWS.restore()
+  afterEach: () => AWS.restore();
 }

--- a/test/renderer/index.js
+++ b/test/renderer/index.js
@@ -3,12 +3,21 @@
 const expect = require('expect.js');
 const _ = require('lodash');
 const AWS = require('aws-sdk-mock');
+const moment = require('moment');
 const sinon = require('sinon');
+const tk = require('timekeeper');
 
 const helpers = require('../helpers');
+const Renderer = require('../../lib/renderer');
 
 describe('Renderer', function() {
   afterEach(helpers.afterEach);
 
+  it('should render duration text', function() {
+    let fakeDate = Date.now();
+    tk.freeze(fakeDate);
 
+    Renderer._setStateStartedAt(moment(fakeDate).subtract(3782, 'seconds'));
+    expect(Renderer._getStateDurationText()).to.equal('1 hours 3 minutes 2 seconds');
+  });
 });

--- a/test/renderer/index.js
+++ b/test/renderer/index.js
@@ -6,12 +6,32 @@ const AWS = require('aws-sdk-mock');
 const moment = require('moment');
 const sinon = require('sinon');
 const tk = require('timekeeper');
+const streamBuffers = require('stream-buffers');
+const EventEmitter = require('events');
 
 const helpers = require('../helpers');
 const Renderer = require('../../lib/renderer');
+const Deployment = require('../../lib/deployment');
+const states = require('../../lib/renderer/states');
 
 describe('Renderer', function() {
-  afterEach(helpers.afterEach);
+  it('should watch deployment for state changes', function(done) {
+    let service = new EventEmitter();
+    let bufferStream = new streamBuffers.WritableStreamBuffer();
+    let deployment = new Deployment({service: service, taskDefinitionArn: 'bla'});
+
+    let _stateChangeOld = Renderer._stateChange;
+    Renderer._stateChange = function(deployment2, output, state) {
+      expect(deployment2).to.equal(deployment);
+      expect(output).to.equal(bufferStream);
+      expect(state).to.equal('newstate');
+      Renderer._stateChange = _stateChangeOld;
+      done();
+    }
+
+    Renderer.watch(deployment, bufferStream);
+    deployment.emit('state', 'newstate');
+  });
 
   it('should render duration text', function() {
     let fakeDate = Date.now();
@@ -19,5 +39,33 @@ describe('Renderer', function() {
 
     Renderer._setStateStartedAt(moment(fakeDate).subtract(3782, 'seconds'));
     expect(Renderer._getStateDurationText()).to.equal('1 hours 3 minutes 2 seconds');
+    tk.reset();
+  });
+
+  it('should process a state change', function(done) {
+    let service = new EventEmitter();
+    let bufferStream = new streamBuffers.WritableStreamBuffer();
+    let deployment = new Deployment({service: service, taskDefinitionArn: 'bla'});
+
+    let taskFailedFixture = {
+      'done': `15 Tasks have failed`,
+      'extra': 'Extra extra hear all about it!',
+      'exitCode': 1
+    };
+
+    let oldTasksFailed = states['TasksFailed'];
+    states['TasksFailed'] = () => taskFailedFixture;
+
+    deployment.on('exitCode', (exitCode) => {
+      let out = bufferStream.getContents().toString();
+      expect(out).to.contain(taskFailedFixture.done);
+      expect(out).to.contain(taskFailedFixture.extra);
+      expect(exitCode).to.equal(taskFailedFixture.exitCode);
+      states['TasksFailed'] = oldTasksFailed;
+      done();
+    });
+
+    Renderer.watch(deployment, bufferStream);
+    deployment.emit('state', 'TasksFailed');
   });
 });

--- a/test/renderer/index.js
+++ b/test/renderer/index.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const expect = require('expect.js');
+const _ = require('lodash');
+const AWS = require('aws-sdk-mock');
+const sinon = require('sinon');
+
+const helpers = require('../helpers');
+
+describe('Renderer', function() {
+  afterEach(helpers.afterEach);
+
+
+});

--- a/test/renderer/states/not-found.js
+++ b/test/renderer/states/not-found.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const expect = require('expect.js');
+const streamBuffers = require('stream-buffers');
+const EventEmitter = require('events');
+const helpers = require('../../helpers');
+
+const Deployment = require('../../../lib/deployment');
+const NotFoundRenderState = require('../../../lib/renderer/states/not-found');
+
+describe('Renderer:State:NotFound', function() {
+  it('should include TaskDefinitionArn in done message', function() {
+    let taskDefinitionArn = 'arn:taskdefinition:1';
+    var service = new EventEmitter();
+    let deployment = new Deployment({service: service, taskDefinitionArn: taskDefinitionArn});
+    let bufferStream = new streamBuffers.WritableStreamBuffer();
+
+    let stateInfo = NotFoundRenderState(deployment, bufferStream);
+    expect(stateInfo.done).to.contain(taskDefinitionArn);
+  });
+});

--- a/test/renderer/states/tasks-failed.js
+++ b/test/renderer/states/tasks-failed.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const expect = require('expect.js');
+const streamBuffers = require('stream-buffers');
+const EventEmitter = require('events');
+const helpers = require('../../helpers');
+
+const Deployment = require('../../../lib/deployment');
+const TasksFailedRenderState = require('../../../lib/renderer/states/tasks-failed');
+
+describe('Renderer:State:TasksFailed', function() {
+  it('should include TaskDefinitionArn in done message', function() {
+    let taskDefinitionArn = 'arn:taskdefinition:1';
+    let service = new EventEmitter();
+    let bufferStream = new streamBuffers.WritableStreamBuffer();
+    let deployment = new Deployment({service: service, taskDefinitionArn: taskDefinitionArn});
+
+    let taskArn='arn:task:1';
+    let stopReason='oh no! the sky is falling!';
+    deployment.tasksFailed.push('arn:task:1');
+    deployment.tasksFailedFull.push({
+      taskArn: taskArn,
+      stoppedReason: stopReason
+    });
+
+    let stateInfo = TasksFailedRenderState(deployment, bufferStream);
+    expect(stateInfo.extra).to.contain(`Task: ${taskArn}\nReason: ${stopReason}`);
+  });
+});

--- a/test/renderer/states/tasks-started.js
+++ b/test/renderer/states/tasks-started.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const expect = require('expect.js');
+const streamBuffers = require('stream-buffers');
+const EventEmitter = require('events');
+const helpers = require('../../helpers');
+
+const Deployment = require('../../../lib/deployment');
+const TasksStartedRenderState = require('../../../lib/renderer/states/tasks-started');
+
+describe('Renderer:State:TasksStarted', function() {
+  it('should include TaskDefinitionArn in done message', function() {
+    let taskDefinitionArn = 'arn:taskdefinition:1';
+    var service = new EventEmitter();
+    let bufferStream = new streamBuffers.WritableStreamBuffer();
+    let deployment = new Deployment({service: service, taskDefinitionArn: taskDefinitionArn});
+    deployment.tasksStarted.push('task1');
+    deployment.tasksStarted.push('task2');
+    deployment.tasksStarted.push('task3');
+
+    let stateInfo = TasksStartedRenderState(deployment, bufferStream);
+    expect(stateInfo.done).to.contain(3);
+  });
+});


### PR DESCRIPTION
I am building a tool which uses `ecs-deployment-monitor` as a dependency. I need to consume the output available when running `ecs-deployment-monitor` via the cli but the output was not modularized. Instead it was contained in the bin script. I have extracted the rendering functionality and made it possible to pass a stream to the module initialization. In addition this makes it possible to test the rendering functionality. 