### PR TITLE
Fix deployment NotFound state due to AWS's eventual consistency

### DIFF
--- a/lib/deployment.js
+++ b/lib/deployment.js
@@ -26,6 +26,7 @@ class Deployment extends EventEmitter {
     this.tasksFailedFull = [];
     this.steady = false;
     this.end = false;
+    this.notFoundCount = 0;
 
     this.history = [];
 
@@ -47,6 +48,11 @@ class Deployment extends EventEmitter {
     });
 
     if (!this.raw) {
+      if (this.notFoundCount < 3) {
+        this.notFoundCount++;
+        return;
+      }
+      
       this.setState('NotFound');
     }
 


### PR DESCRIPTION
AWS's eventual consistency model sometimes causes the deployment to not be found shortly after it was created. This results in the NotFound state being triggered and `ecs-deployment-monitor` exiting the monitoring of the deployment. This PR waits for the deployment to not be found 3 times before erroring out on the 4th on service updates (3 second intervals).