### PR TITLE
Support Fargate services

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ This monitor uses the healthy status on Target Group Targets to determine if a t
 Installation
 ------------
 
-Install package with NPM.
+Install package with NPM. **NOTE:** We have moved the package under our
+`bugcrowd` NPM organization - this will be the only package location maintained
+going forward.
 
-`npm install ecs-deployment-monitor --save`
+`npm install @bugcrowd/ecs-deployment-monitor --save`
 
 Remove `--save` and add the `-g` flag to install globally if you wish to use the CLI version.
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -19,7 +19,7 @@ class Service extends EventEmitter {
     this.tasks = [];
     this.initiated = false;
     this.stop = false;
-    this.launchType = '';
+    this.launchType = 'EC2';
     this.eventBuffer = async.queue(this._eventBufferWorker.bind(this));
 
     this.options = _.defaults(options, {
@@ -219,6 +219,52 @@ class Service extends EventEmitter {
   }
 
   /**
+   * Get Targets For EC2 Task
+   *
+   * Finds the load balancer targets for the EC2 task based on container instances.
+   *
+   * @param {object} task The task we are resolving targets for.
+   * @param {object} container The specific container we are looking for targets associated with.
+   * @return {array} A list of targets
+   */
+  _getTargetsForEC2Task(task, container) {
+    const containerInstance = this.getContainerInstance(task.containerInstanceArn);
+
+    return container.networkBindings.map((binding) => {
+      return this.getTarget(containerInstance.ec2InstanceId, binding.hostPort);
+    }).filter((target) => !!target);
+  }
+
+  /**
+   * Get Targets For Fargate Task
+   *
+   * Finds the load balancer targets for the Farget task based on elastic network
+   * interface IPs.
+   *
+   * @param {object} task The task we are resolving targets for.
+   * @param {object} containerPort Container port that is used with the target group.
+   * @return {array} A list of targets
+   */
+  _getTargetsForFargateTask(task, containerPort) {
+    // Fargate is slightly simpler than EC2 launch type. All tasks are registered
+    // against target group with the IP of its dedicated ENI. The health of the
+    // task is simply the health of the target entry for the task, which we
+    // already have from the targets array. All containers in the same task use
+    // the same IP (but different ports).
+    // There are some caveats here - neither multiple target groups targeting
+    // the same tasks (but different ports), nor IPv6 addresses are handled.
+    const taskIP = task.attachments[0].details.find((detail) => detail.name === 'privateIPv4Address').value;
+    logger.debug(`${task.taskArn} has IP ${taskIP} and port ${containerPort}`);
+
+    const targetsForThisTask = this.targets.filter((target) => {
+      return target.Target.Ip === taskIP && target.Target.Port === containerPort;
+    });
+    logger.debug(`Matched ${targetsForThisTask.length} target(s) for this task`);
+
+    return targetsForThisTask;
+  }
+
+  /**
    * Update service, target health and cluster instance details
    */
   update() {
@@ -331,38 +377,33 @@ class Service extends EventEmitter {
    * @return {boolean}
    */
   isTaskHealthy(taskArn) {
-    var task = this.getTask(taskArn);
+    let task = this.getTask(taskArn);
     if (!task) {
       this.emit('warning', `Task ${taskArn} does not exist. Or has not been cached against the service`);
       return false;
     }
 
-    // Fargate is much simpler than EC2 launch type. All tasks are registered
-    // against target group with the IP of its dedicated ENI. The health of the
-    // task is simply the health of the target entry for the task, which we
-    // already have from the targets array.
-    if (this.launchType === 'FARGATE') {
-      const isHealthy = _.every(this.targets, (target) => 'healthy' === target.TargetHealth.State);
-      logger.info(`Health over all targets in ${taskArn} is ${isHealthy}`);
-      return isHealthy;
-    }
+    // Most of this logic is identical for Fargate- and EC2-backed containers,
+    // except for the inner logic around finding the targets.
+    const isHealthy = this.raw.loadBalancers.every((lb) => {
+      const container = task.containers.find((container) => container.name === lb.containerName);
 
-    var containerInstance = this.getContainerInstance(task.containerInstanceArn);
-
-    var healthy = _.every(this.raw.loadBalancers, (lb) => {
-      var container = _.find(task.containers, (container) => container.name === lb.containerName);
-      var targets = _.filter(_.map(container.networkBindings, (binding) => {
-        return this.getTarget(containerInstance.ec2InstanceId, binding.hostPort);
-      }, (target) => !!target));
+      const targets = (this.launchType === 'FARGATE') ?
+        this._getTargetsForFargateTask(task, lb.containerPort) :
+        this._getTargetsForEC2Task(task, container);
 
       // If no targets were found for the container, then container
       // is not registered with Load Balancer yet.
-      if (targets.length === 0) return false;
+      if (targets.length === 0) {
+        logger.debug(`No targets for ${task.taskArn} found registered with target group ${lb.targetGroupArn}`);
+        return false;
+      }
 
-      return _.every(targets, (target) => 'healthy' === target.TargetHealth.State);
+      return targets.every((target) => 'healthy' === target.TargetHealth.State);
     });
 
-    return healthy;
+    logger.info(`Health over all targets for ${taskArn} is ${isHealthy}`);
+    return isHealthy;
   }
 
   /**

--- a/lib/service.js
+++ b/lib/service.js
@@ -387,6 +387,10 @@ class Service extends EventEmitter {
     // except for the inner logic around finding the targets.
     const isHealthy = this.raw.loadBalancers.every((lb) => {
       const container = task.containers.find((container) => container.name === lb.containerName);
+      if (!container) {
+        logger.error(`Found no matching LB container name for ${container.name}`);
+        return false;
+      }
 
       const targets = (this.launchType === 'FARGATE') ?
         this._getTargetsForFargateTask(task, lb.containerPort) :

--- a/lib/service.js
+++ b/lib/service.js
@@ -19,6 +19,7 @@ class Service extends EventEmitter {
     this.tasks = [];
     this.initiated = false;
     this.stop = false;
+    this.launchType = '';
     this.eventBuffer = async.queue(this._eventBufferWorker.bind(this));
 
     this.options = _.defaults(options, {
@@ -45,7 +46,11 @@ class Service extends EventEmitter {
     };
 
     ecs.describeServices(params, (err, data) => {
-      if (err) return cb(err);
+      if (err) {
+        logger.error(err.message);
+        return cb(err);
+      }
+      logger.info("Retrieved service data for " + data['services'][0]['serviceArn']);
       cb(null, data['services'][0]);
     });
   }
@@ -224,6 +229,7 @@ class Service extends EventEmitter {
         this._service((err, data) => {
           if (err) return next(err);
           this.raw = data;
+          this.launchType = this.raw['launchType']; // Fargate or EC2
           this.primaryDeployment = _.find(this.raw['deployments'], (deployment) => deployment.status === "PRIMARY");
           next();
         });
@@ -231,15 +237,29 @@ class Service extends EventEmitter {
 
       (next) => {
         this._targets((err, targets) => {
-          if (err) return next(err);
+          if (err) {
+            logger.error(err.message);
+            return next(err);
+          }
+
+          logger.info(`Found ${targets.length} targets for this service`);
           this.targets = targets;
           next();
         });
       },
 
       (next) => {
+        if (this.launchType === 'FARGATE') {
+          logger.info('Service is of launch type Fargate, not retrieving container instances');
+          return next();
+        }
+
         this._clusterContainerInstances((err, instances) => {
-          if (err) return next(err);
+          if (err) {
+            logger.error(err.message);
+            return next(err);
+          }
+
           this.clusterContainerInstances = instances;
           next();
         });
@@ -247,7 +267,11 @@ class Service extends EventEmitter {
 
       (next) => {
         this._tasks((err, tasks) => {
-          if (err) return next(err);
+          if (err) {
+            logger.error(err.message);
+            return next(err);
+          }
+
           this.tasks = tasks;
           next();
         });
@@ -311,6 +335,16 @@ class Service extends EventEmitter {
     if (!task) {
       this.emit('warning', `Task ${taskArn} does not exist. Or has not been cached against the service`);
       return false;
+    }
+
+    // Fargate is much simpler than EC2 launch type. All tasks are registered
+    // against target group with the IP of its dedicated ENI. The health of the
+    // task is simply the health of the target entry for the task, which we
+    // already have from the targets array.
+    if (this.launchType === 'FARGATE') {
+      const isHealthy = _.every(this.targets, (target) => 'healthy' === target.TargetHealth.State);
+      logger.info(`Health over all targets in ${taskArn} is ${isHealthy}`);
+      return isHealthy;
     }
 
     var containerInstance = this.getContainerInstance(task.containerInstanceArn);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,1251 @@
 {
   "name": "ecs-deployment-monitor",
-  "version": "0.2.3",
-  "lockfileVersion": 1,
+  "version": "0.2.4",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "0.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.1.0",
+        "aws-sdk": "^2.587.0",
+        "colors": "^1.4.0",
+        "indent": "0.0.2",
+        "inflection": "^1.12.0",
+        "lodash": "^4.17.15",
+        "moment": "^2.24.0",
+        "requirize": "^0.2.0",
+        "winston": "^3.2.1",
+        "yargs": "^15.0.2"
+      },
+      "bin": {
+        "ecs-deployment-monitor": "bin/ecs-deployment-monitor"
+      },
+      "devDependencies": {
+        "aws-sdk-mock": "^4.5.0",
+        "expect.js": "^0.3.1",
+        "mocha": "^5.2.0",
+        "sinon": "^6.3.5",
+        "stream-buffers": "^3.0.2",
+        "timekeeper": "^2.2.0"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
+    "node_modules/@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+      "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
+      "dependencies": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
+    },
+    "node_modules/async": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
+      "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.587.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.587.0.tgz",
+      "integrity": "sha512-MAdUE4BC+hyfFPoQc61aV/tIfApp5ifqe3segW4GJq6dMmSCZdFbDwvs5ZUkgOSJ4ks3ZrpH9eCHpt6r0dFJYQ==",
+      "dependencies": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-sdk-mock": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-4.5.0.tgz",
+      "integrity": "sha512-PAZKbQsdaVVoMr1JZbi04FUrkxCK16qnwBWLm4keeBrEfqYab/cFNsn5IVp/ThdMQpJGYHnmqUPyFq1plKaHZg==",
+      "dev": true,
+      "dependencies": {
+        "aws-sdk": "^2.483.0",
+        "sinon": "^7.3.2",
+        "traverse": "^0.6.6"
+      }
+    },
+    "node_modules/aws-sdk-mock/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/aws-sdk-mock/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/aws-sdk-mock/node_modules/sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
+      }
+    },
+    "node_modules/aws-sdk-mock/node_modules/sinon/node_modules/@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "node_modules/aws-sdk-mock/node_modules/sinon/node_modules/lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
+      "dev": true
+    },
+    "node_modules/aws-sdk-mock/node_modules/sinon/node_modules/nise": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/aws-sdk-mock/node_modules/sinon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/buffer/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "dependencies": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "node_modules/color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/colornames": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "dependencies": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "dependencies": {
+        "env-variable": "0.0.x"
+      }
+    },
+    "node_modules/env-variable": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
+      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/expect.js": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
+      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
+      "dev": true
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "node_modules/fecha": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "node_modules/indent": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/indent/-/indent-0.0.2.tgz",
+      "integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk="
+    },
+    "node_modules/inflection": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
+      "engines": [
+        "node >= 0.4.0"
+      ]
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
+    "node_modules/kuler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+      "dependencies": {
+        "colornames": "^1.1.1"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "node_modules/logform": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
+      "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
+      "dependencies": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
+    "node_modules/logform/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/lolex": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "dependencies": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/mocha/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/nise": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+      "integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/formatio": "^3.1.0",
+        "just-extend": "^4.0.2",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/formatio": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/samsam": "^2 || ^3"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
+    },
+    "node_modules/p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/path-to-regexp/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+      "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readable-stream/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "node_modules/requirize": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/requirize/-/requirize-0.2.0.tgz",
+      "integrity": "sha512-1NhHKj5eooy/flVnRt1QVfnYsyjZxEhViPp2rcpQMwis6bA+Ni6+Vy4p/yA0KLrDbkTuzFsPNQYEOUB1j80QcA==",
+      "dependencies": {
+        "underscore.string": "^3.3.5"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "node_modules/sinon": {
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.3.5.tgz",
+      "integrity": "sha512-xgoZ2gKjyVRcF08RrIQc+srnSyY1JDJtxu3Nsz07j1ffjgXoY6uPLf/qja6nDBZgzYYEovVkFryw2+KiZz11xQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/formatio": "^3.0.0",
+        "@sinonjs/samsam": "^2.1.2",
+        "diff": "^3.5.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.7.5",
+        "nise": "^1.4.5",
+        "supports-color": "^5.5.0",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/formatio/node_modules/@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/samsam": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.3.tgz",
+      "integrity": "sha512-8zNeBkSKhU9a5cRNbpCKau2WWPfan+Q2zDlcXvXyhn9EsMqgYs4qzo0XHNVlXC6ABQL8fT6nV+zzo5RTHJzyXw==",
+      "dev": true
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/lolex": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+      "dev": true
+    },
+    "node_modules/sinon/node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stream-buffers": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
+      "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
+    "node_modules/timekeeper": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.2.0.tgz",
+      "integrity": "sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==",
+      "dev": true
+    },
+    "node_modules/traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
+    "node_modules/triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/underscore.string": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+      "dependencies": {
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "node_modules/winston": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+      "dependencies": {
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+      "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+      "dependencies": {
+        "readable-stream": "^2.3.6",
+        "triple-beam": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/winston-transport/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/winston-transport/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/winston-transport/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/winston/node_modules/async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+    },
+    "node_modules/yargs": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.0.2.tgz",
+      "integrity": "sha512-GH/X/hYt+x5hOat4LMnCqMd8r5Cv78heOMIJn1hr7QPPBqfeC6p89Y78+WB9yGDvfpCvgasfmWLzNzEioOUD9Q==",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^16.1.0"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+      "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    }
+  },
   "dependencies": {
     "@sinonjs/commons": {
       "version": "1.6.0",
@@ -111,17 +1354,8 @@
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "nise": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
-          "integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
-          "requires": {
-            "lolex": "^2.3.2",
-            "path-to-regexp": "^1.7.0",
-            "text-encoding": "^0.6.4"
-          }
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "sinon": {
           "version": "7.5.0",
@@ -177,19 +1411,6 @@
               }
             }
           }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "type-detect": {
-          "version": "4.0.8",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
         }
       }
     },
@@ -500,7 +1721,8 @@
     "lolex": {
       "version": "2.7.5",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q=="
+      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -694,6 +1916,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
       "requires": {
         "isarray": "0.0.1"
       },
@@ -701,7 +1924,8 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         }
       }
     },
@@ -867,6 +2091,14 @@
       "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -875,14 +2107,6 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -905,7 +2129,8 @@
     "text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "text-hex": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ecs-deployment-monitor",
-  "version": "0.2.4",
+  "name": "@bugcrowd/ecs-deployment-monitor",
+  "version": "0.2.5-rc0",
   "description": "Monitor an ECS Deployment",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures/fargate-deployment.json
+++ b/test/fixtures/fargate-deployment.json
@@ -1,0 +1,584 @@
+{
+  "services": [
+    {
+      "serviceArn": "arn:aws:ecs:us-east-1:12345789012:service/mycluster/my-test-application",
+      "serviceName": "my-test-application",
+      "clusterArn": "arn:aws:ecs:us-east-1:12345789012:cluster/mycluster",
+      "loadBalancers": [
+        {
+          "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:12345789012:targetgroup/my-test-application-target-group/80f23589c50342f5",
+          "containerName": "app",
+          "containerPort": 8443
+        }
+      ],
+      "serviceRegistries": [],
+      "status": "ACTIVE",
+      "desiredCount": 3,
+      "runningCount": 3,
+      "pendingCount": 0,
+      "launchType": "FARGATE",
+      "platformVersion": "LATEST",
+      "taskDefinition": "arn:aws:ecs:us-east-1:12345789012:task-definition/my-test-application:20",
+      "deploymentConfiguration": {
+        "maximumPercent": 200,
+        "minimumHealthyPercent": 100
+      },
+      "deployments": [
+        {
+          "id": "ecs-svc/7446793752848331910",
+          "status": "PRIMARY",
+          "taskDefinition": "arn:aws:ecs:us-east-1:12345789012:task-definition/my-test-application:20",
+          "desiredCount": 3,
+          "pendingCount": 0,
+          "runningCount": 3,
+          "createdAt": "2021-08-17T11:48:19.999Z",
+          "updatedAt": "2021-08-17T11:56:13.784Z",
+          "launchType": "FARGATE",
+          "platformVersion": "1.4.0",
+          "networkConfiguration": {
+            "awsvpcConfiguration": {
+              "subnets": [
+                "subnet-00000000000000000",
+                "subnet-11111111111111111",
+                "subnet-22222222222222222",
+                "subnet-33333333333333333"
+              ],
+              "securityGroups": [
+                "sg-00000000000000000",
+                "sg-11111111111111111"
+              ],
+              "assignPublicIp": "DISABLED"
+            }
+          }
+        }
+      ],
+      "roleArn": "arn:aws:iam::12345789012:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+      "events": [
+        {
+          "id": "47ab98ee-4ea0-4e45-a36b-93c770228d53",
+          "createdAt": "2021-08-18T11:57:32.630Z",
+          "message": "(service my-test-application) has reached a steady state."
+        },
+        {
+          "id": "357af273-0667-446c-a128-37e9e6ac22a5",
+          "createdAt": "2021-08-18T05:57:10.963Z",
+          "message": "(service my-test-application) has reached a steady state."
+        },
+        {
+          "id": "9ec99dab-4a4e-4050-bbeb-47d136c3bac3",
+          "createdAt": "2021-08-17T23:56:40.877Z",
+          "message": "(service my-test-application) has reached a steady state."
+        },
+        {
+          "id": "46ace201-992e-49ff-ac6a-972dd6222be6",
+          "createdAt": "2021-08-17T17:56:17.583Z",
+          "message": "(service my-test-application) has reached a steady state."
+        },
+        {
+          "id": "858245ac-4f17-4883-97f1-eaceacf531d6",
+          "createdAt": "2021-08-17T11:56:13.791Z",
+          "message": "(service my-test-application) has reached a steady state."
+        },
+        {
+          "id": "4a235042-b56f-4998-b2c4-4349bec91d69",
+          "createdAt": "2021-08-17T11:56:13.790Z",
+          "message": "(service my-test-application) (deployment ecs-svc/7446793752848331910) deployment completed."
+        },
+        {
+          "id": "f1725a78-06f3-4b73-9ded-695cee2ce305",
+          "createdAt": "2021-08-17T11:54:55.898Z",
+          "message": "(service my-test-application) has stopped 3 running tasks: (task 7eaf4df3e6044a6987b5dd92d3c8aa37) (task 149cfbd3b07c46b4b24f644c9fae1ec2) (task b82fb25a6ca64f4ca6a7aaa6ed3484b8)."
+        },
+        {
+          "id": "7cb2d62e-5334-44a4-98bd-73bbcaebc630",
+          "createdAt": "2021-08-17T11:49:52.673Z",
+          "message": "(service my-test-application) has begun draining connections on 3 tasks."
+        },
+        {
+          "id": "a8edfb57-4e8f-494a-9740-f7c83ff80059",
+          "createdAt": "2021-08-17T11:49:52.672Z",
+          "message": "(service my-test-application) deregistered 3 targets in (target-group arn:aws:elasticloadbalancing:us-east-1:12345789012:targetgroup/my-test-application-target-group/80f23589c50342f5)"
+        },
+        {
+          "id": "a0f93e35-e2cc-46d1-97b3-38d32baf4c30",
+          "createdAt": "2021-08-17T11:49:13.585Z",
+          "message": "(service my-test-application) registered 3 targets in (target-group arn:aws:elasticloadbalancing:us-east-1:12345789012:targetgroup/my-test-application-target-group/80f23589c50342f5)"
+        },
+        {
+          "id": "4a0fb9e0-388d-4adf-bcc3-6096b8497b95",
+          "createdAt": "2021-08-17T11:48:43.596Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 2dcb245864614e6b9816196c82cd3814) (task 02821bbfeddc4f00a9100c737338596f) (task df0d0f60978a4834b38dfdb3ef7e1acc)."
+        },
+        {
+          "id": "546e98d1-9136-4192-8b02-eeed905de43f",
+          "createdAt": "2021-08-17T11:43:22.926Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 168f27ca28674745823aa87295214538) (task 1ef11cef12044596ae0b9ce1e5c149e7) (task 18d0da9fe64044818d023b469e88855e)."
+        },
+        {
+          "id": "e824db18-cfb1-4936-b268-f081458086ba",
+          "createdAt": "2021-08-17T11:37:49.554Z",
+          "message": "(service my-test-application) has started 3 tasks: (task c2c3ae27d2ea457cbcbd348283b14ae0) (task c0083c48b7844ab9b8e09808c9a79f02) (task e3a119d2ab064d63bea690dff9c5b2ad)."
+        },
+        {
+          "id": "24648cda-ee6c-4e1c-9742-dc9f75115725",
+          "createdAt": "2021-08-17T11:32:02.429Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 0ba595e87c814b88a4be15773864748a) (task 7bdd6e73e334450281d5f5a7e6550f3c) (task dea4a6166e6b4ed8b1f4041e29913086)."
+        },
+        {
+          "id": "44e3bba7-b403-4bc0-a9eb-67b564bf5d3d",
+          "createdAt": "2021-08-17T11:30:12.796Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "3cebc44f-c09c-4562-a31c-f0d575e3a0e8",
+          "createdAt": "2021-08-17T11:29:52.767Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 447b137fee264d5698b19cbcfe5d835e) (task 386acd8bc79d4c8ba988a9b91bb51ff9) (task 64dd7e60f2f549a5bb353c1fd68d3d6f)."
+        },
+        {
+          "id": "a4b4ede0-9a66-4e30-9319-3457b3888a8e",
+          "createdAt": "2021-08-17T11:15:23.676Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "785ff1ed-f0b3-4a40-94da-79e737799308",
+          "createdAt": "2021-08-17T11:15:04.412Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 1f66b4d38efd45ba9992297491d94b51) (task e464481a52d946d18ae4db1e8254de0e) (task cf1e3ac314f8463eb573ea8703a708ea)."
+        },
+        {
+          "id": "0ed1e6d9-33cc-4c95-a4ca-95fb483b315d",
+          "createdAt": "2021-08-17T10:59:32.304Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "ea0d39f6-1caf-4693-9567-7d43518abbce",
+          "createdAt": "2021-08-17T10:59:13.203Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 5c1e20bfe754449aaf34a13f282c18d9) (task 16b86236d19740d4b12996b965c8e11d) (task 305c3868782743b1818404dea897a9b4)."
+        },
+        {
+          "id": "9e3fc680-55bb-4291-99cf-d0886027dab8",
+          "createdAt": "2021-08-17T10:44:21.218Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "ee7b9e3b-40f6-4bda-bf5d-7671ae1b43fd",
+          "createdAt": "2021-08-17T10:44:00.708Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 93eb82bcf8b94aa6b741ffe1bfab6cd4) (task 2b5de54aa9dc47bd8b3e39672cd18034) (task cd5830d5d260437ab6d5b29434e8a6c5)."
+        },
+        {
+          "id": "dbd67326-2644-4ffa-8172-fe8594e6833b",
+          "createdAt": "2021-08-17T10:28:18.593Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "ee865046-52e4-4995-910f-c4f4ad77b553",
+          "createdAt": "2021-08-17T10:28:00.027Z",
+          "message": "(service my-test-application) has started 3 tasks: (task ccc1a231195f43f0b6ae6e87bc11c865) (task 461fd4de103a480485f52377e8281bf0) (task b92db9bfe6e14ffb867e673d54071416)."
+        },
+        {
+          "id": "67396a6d-2c49-4502-a8f7-c8481928cc14",
+          "createdAt": "2021-08-17T10:12:14.698Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "b7996983-daac-43a4-a79f-9931c6abdb1e",
+          "createdAt": "2021-08-17T10:11:54.475Z",
+          "message": "(service my-test-application) has started 3 tasks: (task d8eb78de4bb04b33b7d7166668ec2eb4) (task 76f52e60a73a42f09ac955af3796925e) (task 1a3e72b7725640dca2a3a7d1d56d1fa7)."
+        },
+        {
+          "id": "ade53f46-fb4c-4428-9a22-75ead7b5a03b",
+          "createdAt": "2021-08-17T09:57:06.862Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "5ed57fb0-3295-467d-894f-74eaeafccfa3",
+          "createdAt": "2021-08-17T09:56:47.970Z",
+          "message": "(service my-test-application) has started 3 tasks: (task ebd23aa3396d4ed6938d91ef60095f9c) (task 7637e12f01d84d33951d991e009483b0) (task 0c5f19b53f2f4fb4bb663e512dbfaeb6)."
+        },
+        {
+          "id": "2ed57049-b4f5-4e60-84d2-d90b4b064368",
+          "createdAt": "2021-08-17T09:42:19.435Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "a567577a-e587-4e2f-8660-9b9d1a7cb756",
+          "createdAt": "2021-08-17T09:42:00.188Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 82543067e1e14c92be7829c33be76c63) (task 09db827a6eb24248b557cd0dff7250bb) (task 973cd18ccb174a6fbf3677e5aafc70a4)."
+        },
+        {
+          "id": "18a328ce-2dfb-4622-ad16-24a817a3f6e3",
+          "createdAt": "2021-08-17T09:27:26.322Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "217f63ef-24ee-4cd6-91c8-203752c80e5f",
+          "createdAt": "2021-08-17T09:27:06.629Z",
+          "message": "(service my-test-application) has started 2 tasks: (task 952ca46e36a8417c8e97187e8fca0a43) (task 01eb9804febf43dfa07ba7748763c1b7)."
+        },
+        {
+          "id": "efa7b700-64f3-45b8-82c3-d40b945d83e1",
+          "createdAt": "2021-08-17T09:26:55.672Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "b7311fa1-47bc-4d45-8790-0ae0cb117a3e",
+          "createdAt": "2021-08-17T09:26:36.176Z",
+          "message": "(service my-test-application) has started 2 tasks: (task 7b86628a26cf4060b42440817a3da302) (task 9704450dc7da4e768fbfc2fe47a6a572)."
+        },
+        {
+          "id": "d56e2345-2bb3-4f0b-a298-8f055e89d2a0",
+          "createdAt": "2021-08-17T09:26:25.262Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "c6240efd-7f48-4453-94a8-743b41cf07f2",
+          "createdAt": "2021-08-17T09:26:04.307Z",
+          "message": "(service my-test-application) has started 3 tasks: (task f1f9c5e5a9b04a4eb5f60797f7853111) (task 6080f9802bad4bd29be200b1608852a5) (task 66d84fb14ddf4009b4ae2469ed11c601)."
+        },
+        {
+          "id": "38af61fb-0c6c-4fcb-9c6f-a1dfafd1b6c4",
+          "createdAt": "2021-08-17T09:10:31.461Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "e3d1b270-cb4f-4ba5-8c75-b94d252b23d7",
+          "createdAt": "2021-08-17T09:10:13.103Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 7f4e4470faae4ce2bc659c4cd4dc4b32) (task b0ae4623888548d4b9a43ddc1aa41cb1) (task 3dbefe2b84e54b71b55c07be74664218)."
+        },
+        {
+          "id": "2241ddc8-c6a3-4a87-a29b-2943e61932b1",
+          "createdAt": "2021-08-17T08:55:56.470Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "b727e405-c900-4071-bd8b-54f9414a1de7",
+          "createdAt": "2021-08-17T08:55:37.959Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 8a09976f3fcf407793def1fa025c72c3) (task b5ea8cdd7b9b43babf7b3903a49ce6d5) (task 1ce42700ee5744a1b0b3d17d477f08b0)."
+        },
+        {
+          "id": "a0c7ab44-5938-4d24-8b10-8d592e81d292",
+          "createdAt": "2021-08-17T08:40:41.418Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "742843ff-2f8b-4903-9506-7a08679a934b",
+          "createdAt": "2021-08-17T08:40:23.208Z",
+          "message": "(service my-test-application) has started 3 tasks: (task d44c1ad923754194857963d30b56aa88) (task da1406b99a1b4bac8c6b7d3123cb1ec6) (task 65fb9979d0c24904889dd57ac90e65b7)."
+        },
+        {
+          "id": "99917eef-ba84-41a4-bfa0-27fa1ac872e3",
+          "createdAt": "2021-08-17T08:25:40.997Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "fcaa75be-b70c-4b35-84a4-a80d79aae11e",
+          "createdAt": "2021-08-17T08:25:21.135Z",
+          "message": "(service my-test-application) has started 3 tasks: (task ad29af455b354405a2031350cbdb91a7) (task dc780253e640405ca44d953db5925ce5) (task 173f600d044349a3a1b18ff5b3284ded)."
+        },
+        {
+          "id": "2460cf29-1083-450d-a846-5e06589e8240",
+          "createdAt": "2021-08-17T08:10:43.723Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "cf2a683b-b63c-475b-81b9-4b7832f53b5e",
+          "createdAt": "2021-08-17T08:10:24.139Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 8fccae2a71424b9dba471344f1079fa7) (task 6a835d5a6a504783b093b94853089670) (task 72526517bf50438cad2ee0707afd25e4)."
+        },
+        {
+          "id": "cce904be-075d-47ae-b8e7-13fa784dfaf5",
+          "createdAt": "2021-08-17T07:54:55.222Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "9f417f04-1167-47bb-a2d8-3073b6db61d5",
+          "createdAt": "2021-08-17T07:54:34.372Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 9196009880ce4ed08c8b763cc307a86a) (task bf1ce39765a046688d0d9c71c50f05fe) (task 38b95d9c686d4efd8730ce1275843a98)."
+        },
+        {
+          "id": "f7abe217-193f-4480-a548-663bae0b8a45",
+          "createdAt": "2021-08-17T07:39:24.875Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "c4613aea-829c-4b52-a50e-6bdf2d13f510",
+          "createdAt": "2021-08-17T07:39:06.695Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 50a8ef587eab4da080199b74296ad54c) (task 6cc80bc063814dcfad5529e507d3d6b4) (task a38502e601924000b7cfb4e7495df516)."
+        },
+        {
+          "id": "88e80d2c-f356-4533-912f-359e56a42bf3",
+          "createdAt": "2021-08-17T07:24:10.816Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "6b3fe4ae-6cd1-45ed-91e1-a10ef9944c0f",
+          "createdAt": "2021-08-17T07:23:51.842Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 50fdb0162b1943c292aa6fcb0d5e1538) (task 0aeba94c5b4c461b9118e4e6fab60d54) (task 96d80ae05eee413589f3ae06fcecaf43)."
+        },
+        {
+          "id": "15bce47a-d497-4eed-b400-8d4ff032d76f",
+          "createdAt": "2021-08-17T07:09:07.139Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "59c81149-a98e-4770-ab75-62fe5a636c94",
+          "createdAt": "2021-08-17T07:08:48.614Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 14b484672d9242ffab72b744077e3763) (task 685123424de34cf98721f673164c96d6) (task 0c3626b62a374b94ab2988331d95e0d2)."
+        },
+        {
+          "id": "87efab97-b523-47af-a7e3-e35ab1daeb14",
+          "createdAt": "2021-08-17T06:53:36.355Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "6ff7e6cd-6d8c-4499-897e-ac3697ae44a4",
+          "createdAt": "2021-08-17T06:53:17.599Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 10b3bbf2e0e842d59b798147568c5312) (task 1e7023d1f0014ba7b1a93551dff87efa) (task 777f5ce447054e3a8c58c9298fc63aba)."
+        },
+        {
+          "id": "93c02ce9-cd40-4c0d-9046-54aa7ab3c150",
+          "createdAt": "2021-08-17T06:38:44.183Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "a874dd33-6641-46d6-93f0-a1943df552b4",
+          "createdAt": "2021-08-17T06:38:25.247Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 7951ef6ffc30489e9f4dcb3ba381fd79) (task dd85dcf9e97f4a4d893b2b9467385921) (task bcbe578044c84641827f789929735abe)."
+        },
+        {
+          "id": "a113a63e-112c-4aa6-9312-722a07c5a280",
+          "createdAt": "2021-08-17T06:23:37.121Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "1d83aa0f-3cd3-4222-954f-428219d21493",
+          "createdAt": "2021-08-17T06:23:18.071Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 0ce6241614484fd89e44f905cc076c99) (task 38188e35b6a44aa980dd7867076bed2e) (task 030fa769c0434c9c89b9555e75edb03c)."
+        },
+        {
+          "id": "820016b7-de6e-4705-b673-f4867b239b57",
+          "createdAt": "2021-08-17T06:08:22.316Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "7c96b3bf-5d8f-4660-aa9c-dfa45b24751e",
+          "createdAt": "2021-08-17T06:08:02.708Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 2245720a162744aea47a585534cd5a88) (task 97e1abafd3c34a198a3718c4cca935e4) (task 137d540b71624c0faf37cbe48d7ab894)."
+        },
+        {
+          "id": "4189f09a-14d2-4c36-a0cb-30f597211f9b",
+          "createdAt": "2021-08-17T05:52:19.349Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "09c650ec-5071-4e8c-9719-0c036d354f74",
+          "createdAt": "2021-08-17T05:51:59.296Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 325df44b499d4eb685af991dd90d13bf) (task f9d407cc03514976a9c11d00652b82eb) (task 987d6f73bd4744b2849e1414c07fc1a3)."
+        },
+        {
+          "id": "cc17025e-4fde-4f2c-b4f6-c401210e5cc1",
+          "createdAt": "2021-08-17T05:36:48.461Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "5cae8d11-e120-40f9-ba7c-663077b50485",
+          "createdAt": "2021-08-17T05:36:29.542Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 3f84dd2bf5de4fcebf8aaa5cc42d818d) (task f0d8cdb83afc43d48a0f0018f014ead5) (task 8702933475cd4cad863c6584b527cded)."
+        },
+        {
+          "id": "419d2759-85f9-4868-a279-d3e69d9c3b02",
+          "createdAt": "2021-08-17T05:21:24.758Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "be320c9f-a8b1-457f-83c4-834042e4eedc",
+          "createdAt": "2021-08-17T05:21:05.714Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 33c9cb9dc22e4b698beb642e716e2f45) (task 08e1d66c2f4749f9bdb2802b51d11ca5) (task b5a08806781d4f879a8317175964a288)."
+        },
+        {
+          "id": "02092c05-dcd5-4e6c-81b4-d0b07bc9cbe4",
+          "createdAt": "2021-08-17T05:05:58.581Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "01b21326-4887-4439-8a3a-5dad5f353331",
+          "createdAt": "2021-08-17T05:05:39.637Z",
+          "message": "(service my-test-application) has started 3 tasks: (task e65505daa5f446d8a85ac91e7c86300b) (task 52a83597d1e841eda826dd21b5f51835) (task 77d39f3c073341d5a6054ab0701ec86f)."
+        },
+        {
+          "id": "80b00712-4c11-4a4c-9982-9426bc6a5a0c",
+          "createdAt": "2021-08-17T04:50:02.937Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "acc2f9d9-a3c2-42ed-b3fa-7e2ae7746a3d",
+          "createdAt": "2021-08-17T04:49:42.542Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 13c7babf65fb4811a9aef4632972a70d) (task 1791124f5e2b4f4b9c6eeec4ffbbb8fc) (task 3e9783820e484f33a104c22c61d5bab5)."
+        },
+        {
+          "id": "9d09c450-1ae4-4b9a-bd70-1181d509a4b0",
+          "createdAt": "2021-08-17T04:34:37.250Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "c23dfd3c-38c7-4817-ae1d-6cdb0433b2d1",
+          "createdAt": "2021-08-17T04:34:17.579Z",
+          "message": "(service my-test-application) has started 3 tasks: (task df2ff52e295949f98383e887d4b35730) (task 36e9e849adc5401fa391f04612ab318c) (task b7aa8b38934b45328f670b61a0abc809)."
+        },
+        {
+          "id": "9ad426f3-c8b9-4861-ba17-ba2d04f3f99e",
+          "createdAt": "2021-08-17T04:19:54.054Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "97961467-9d89-480c-a55d-fd9f96eca851",
+          "createdAt": "2021-08-17T04:19:34.738Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 1360e7164d61484cae95d976db52d348) (task a6e890b1887e48898621c9cbade12221) (task 472b6b1e7ed143a98cd9d5f37afdb477)."
+        },
+        {
+          "id": "32d8b26b-18df-41e0-9598-b9c3a27a273c",
+          "createdAt": "2021-08-17T04:04:05.661Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "42e01d75-b492-4ca3-beca-f76fa11365a6",
+          "createdAt": "2021-08-17T04:03:47.083Z",
+          "message": "(service my-test-application) has started 3 tasks: (task c0d584041b0044b288ae409899631efb) (task 8efe1d53c986480da68c436e1567d496) (task ed8af0d5665848cbbabbaa2243714d2c)."
+        },
+        {
+          "id": "4e164b6a-f54a-40de-aa9a-21989c8a9f11",
+          "createdAt": "2021-08-17T03:49:30.590Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "58b24918-5a3f-49d9-b959-258bbb97eda4",
+          "createdAt": "2021-08-17T03:49:12.206Z",
+          "message": "(service my-test-application) has started 3 tasks: (task fe7d337ff6c0402baa8fa955e879d9c9) (task 936fb6342ffe4b9097b3c4bde2ab7379) (task 2f6a2b276d964ababa1ae971414c97a7)."
+        },
+        {
+          "id": "bce9af29-132b-473e-9245-a1811be3d09f",
+          "createdAt": "2021-08-17T03:33:31.503Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "d58da58d-70b1-49b5-b187-3da200593698",
+          "createdAt": "2021-08-17T03:33:11.196Z",
+          "message": "(service my-test-application) has started 3 tasks: (task dfe71fd103184f4e97433be2e42ca96d) (task a2077606a36c44a392d360ab6f963ba4) (task 86e01bcfd73b4144ba2186ee556e188f)."
+        },
+        {
+          "id": "de14ac84-f2dc-4140-a727-4761f3a61a6c",
+          "createdAt": "2021-08-17T03:18:29.507Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "de870ede-0b64-4633-8a58-5b76a1be2bb3",
+          "createdAt": "2021-08-17T03:18:10.504Z",
+          "message": "(service my-test-application) has started 3 tasks: (task bea21a6ce1474ce386aad362c7649553) (task eacde1b64af3415d87b3f3f5e63f4823) (task 1d8bc6f18b2f4426b5ec48f949010481)."
+        },
+        {
+          "id": "821902b0-b955-4b0a-98b2-51186fa24f06",
+          "createdAt": "2021-08-17T03:02:38.968Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "a4141421-869b-4247-8b10-9772def971e7",
+          "createdAt": "2021-08-17T03:02:19.451Z",
+          "message": "(service my-test-application) has started 3 tasks: (task ce3ac2453dc54b28a100aa6896652050) (task eac827cad4094e3aba0479ac119c3e8e) (task f838edec6a87447fb20433c15dbd572b)."
+        },
+        {
+          "id": "f5d91807-dcfa-4f14-8ccd-95a658575b60",
+          "createdAt": "2021-08-17T02:46:46.295Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "31e5d23d-578f-4bb9-a74d-f768d2822ffe",
+          "createdAt": "2021-08-17T02:46:27.775Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 9644b855fbcd4599abd46614c051a00c) (task 2f626c4f64bb489098e1e35f41edf174) (task 20b52c7e5e3246b0979b57328daac423)."
+        },
+        {
+          "id": "d5bb02d9-e4a4-409e-a193-6f709c525bb9",
+          "createdAt": "2021-08-17T02:31:38.538Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "9658e442-1c3c-4bc0-ab28-fc6b179deb5b",
+          "createdAt": "2021-08-17T02:31:19.618Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 72f781774f2d47949727a898c511cc87) (task 2f556291194d4695a517e519fb271bf2) (task fa139ea2808a4afd91427d9eb6158a46)."
+        },
+        {
+          "id": "1f4765b6-d683-4c3d-87c0-36e9a3dfba22",
+          "createdAt": "2021-08-17T02:16:19.705Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "fc81d888-fab6-438e-b2dc-e527cf0e3d03",
+          "createdAt": "2021-08-17T02:15:59.593Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 02f7e7ea5c2c489483bfb4d3da09f8e7) (task e8a7de3c198e4c7e8b3dbe84d0bd8ed1) (task aea4923c432f4adeaa89b41569f48a7d)."
+        },
+        {
+          "id": "976e899c-9be1-4634-beae-4b6acb6595a2",
+          "createdAt": "2021-08-17T02:00:54.026Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "b4bc3ccf-8771-4713-b4ae-23e688876427",
+          "createdAt": "2021-08-17T02:00:34.766Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 6cf592d5f1e548c6bcf4c10f69e00083) (task b3d327506718420bb90c65213cc7c45d) (task 373230ea278b4a298d1efd97209f6417)."
+        },
+        {
+          "id": "d6996f72-ef14-4fcd-83a7-7040fb811bcb",
+          "createdAt": "2021-08-17T01:45:30.318Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "9f3943b4-95c6-4a0f-b6e9-eb65461c4bd0",
+          "createdAt": "2021-08-17T01:45:09.582Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 88fcf8099be74a7b970fbab36df96d3b) (task 57ff0943dc3547fa95b6fe7ee920157c) (task eadec833bde4478094a29ab3166a55e1)."
+        },
+        {
+          "id": "bf3a6c6e-1f9e-4f0b-910c-57e66fc3ada8",
+          "createdAt": "2021-08-17T01:30:52.003Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "dc6daf29-c6b1-449c-8e0a-8a25b640c99d",
+          "createdAt": "2021-08-17T01:30:31.118Z",
+          "message": "(service my-test-application) has started 3 tasks: (task c682ef59b3984a21b630d57b0e3675e2) (task 85c435afb75b4d9aa47f4f3c602aec09) (task cae9f918f75f464884af708570feb409)."
+        },
+        {
+          "id": "6c04ee65-d697-4fc8-a81f-2e5e7bec27c4",
+          "createdAt": "2021-08-17T01:15:59.301Z",
+          "message": "(service my-test-application) is unable to consistently start tasks successfully. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide."
+        },
+        {
+          "id": "ef542bea-e8fa-4e01-9806-2051fa1e474d",
+          "createdAt": "2021-08-17T01:15:40.386Z",
+          "message": "(service my-test-application) has started 3 tasks: (task 2caddf2b4ae54328adc158e42e42a5ee) (task 99935e90df264860b1fa47bb33034751) (task 4677ce87ff254cebb6a737a06ffc0f64)."
+        }
+      ],
+      "createdAt": "2021-08-09T10:33:02.311Z",
+      "placementConstraints": [],
+      "placementStrategy": [],
+      "networkConfiguration": {
+        "awsvpcConfiguration": {
+          "subnets": [
+            "subnet-00000000000000000",
+            "subnet-11111111111111111",
+            "subnet-22222222222222222",
+            "subnet-33333333333333333"
+          ],
+          "securityGroups": [
+            "sg-00000000000000000",
+            "sg-11111111111111111"
+          ],
+          "assignPublicIp": "DISABLED"
+        }
+      },
+      "healthCheckGracePeriodSeconds": 0,
+      "schedulingStrategy": "REPLICA",
+      "createdBy": "arn:aws:iam::12345789012:role/deployer",
+      "enableECSManagedTags": false,
+      "propagateTags": "NONE"
+    }
+  ],
+  "failures": []
+}

--- a/test/service.js
+++ b/test/service.js
@@ -53,13 +53,13 @@ describe('Service', function() {
   describe('Constructor', function() {
     it('should return call describeServices with correct params', function(done) {
       AWS.mock('ECS', 'describeServices', function (params, cb){
-        expect(params.cluster).to.equal('cluster-yo');
-        expect(params.services).to.eql(['service-yo']);
+        expect(params.cluster).to.equal('cluster-yo0');
+        expect(params.services).to.eql(['service-yo0']);
         service.destroy();
         done();
       });
 
-      var service = new Service({clusterArn: 'cluster-yo', serviceName: 'service-yo'});
+      var service = new Service({clusterArn: 'cluster-yo0', serviceName: 'service-yo0'});
     });
 
     it('should return call _clusterContainerInstances', function(done) {
@@ -67,7 +67,7 @@ describe('Service', function() {
         cb(null, fixtures['newDeployment']);
       });
 
-      var service = new Service({clusterArn: 'cluster-yo', serviceName: 'service-yo'});
+      var service = new Service({clusterArn: 'cluster-yo1', serviceName: 'service-yo1'});
       service.on('updated', () => {
         expect(service.clusterContainerInstances).to.eql(['instance']);
         done();
@@ -81,7 +81,7 @@ describe('Service', function() {
         cb(null, fixtures['newDeployment']);
       });
 
-      var service = new Service({clusterArn: 'cluster-yo', serviceName: 'service-yo'});
+      var service = new Service({clusterArn: 'cluster-yo2', serviceName: 'service-yo2'});
       var events = service._pluckEventsSince(fixtures['newDeployment']['services'][0]['events'], 1494960755);
       service.destroy();
 
@@ -98,7 +98,7 @@ describe('Service', function() {
         cb(null, { tasks: [1,2,3,4] });
       });
 
-      var service = new Service({clusterArn: 'cluster-yo', serviceName: 'service-yo'});
+      var service = new Service({clusterArn: 'cluster-yo3', serviceName: 'service-yo3'});
 
       service.on('event', (event) => {
         expect(event.raw.id).to.equal("e1e75594-b9c9-4c32-bb90-89801bd89a62");
@@ -138,7 +138,11 @@ describe('Service', function() {
         });
       });
 
-      var service = new Service({clusterArn: 'cluster-yo', serviceName: 'service-yo'});
+      AWS.mock('ECS', 'describeServices', (params, cb) => {
+        cb(null, fixtures['newDeployment']);
+      });
+
+      var service = new Service({clusterArn: 'cluster-yo4', serviceName: 'service-yo4'});
       service.on('updated', () => {
         expect(service.targets.length).to.equal(1);
         done();
@@ -150,7 +154,11 @@ describe('Service', function() {
         cb(null, fixtures['newDeployment']);
       });
 
-      var service = new Service({clusterArn: 'cluster-yo', serviceName: 'service-yo'});
+      AWS.mock('ECS', 'describeServices', (params, cb) => {
+        cb(null, fixtures['newDeployment']);
+      });
+
+      var service = new Service({clusterArn: 'cluster-yo5', serviceName: 'service-yo5'});
       service.on('updated', () => {
         service.targets = [
           {
@@ -188,7 +196,7 @@ describe('Service', function() {
       containerInstanceStub.restore();
 
       AWS.mock('ECS', 'listContainerInstances', function (params, cb) {
-        expect(params.cluster).to.equal('cluster-yo');
+        expect(params.cluster).to.equal('cluster-yo6');
 
         cb(null, {
           containerInstanceArns: [
@@ -199,7 +207,7 @@ describe('Service', function() {
       });
 
       AWS.mock('ECS', 'describeContainerInstances', function (params, cb) {
-        expect(params.cluster).to.equal('cluster-yo');
+        expect(params.cluster).to.equal('cluster-yo6');
 
         cb(null, {
           containerInstances: [
@@ -209,7 +217,11 @@ describe('Service', function() {
         });
       });
 
-      var service = new Service({clusterArn: 'cluster-yo', serviceName: 'service-yo'});
+      AWS.mock('ECS', 'describeServices', (params, cb) => {
+        cb(null, fixtures['newDeployment']);
+      });
+
+      var service = new Service({clusterArn: 'cluster-yo6', serviceName: 'service-yo6'});
       service._clusterContainerInstances((err, containerInstances) => {
         expect(containerInstances.length).to.equal(2);
         expect(containerInstances[0].ec2InstanceId).to.equal('i-1');
@@ -223,8 +235,8 @@ describe('Service', function() {
       serviceTasks.restore();
 
       AWS.mock('ECS', 'listTasks', function (params, cb) {
-        expect(params.cluster).to.equal('cluster-yo');
-        expect(params.serviceName).to.equal('service-yo');
+        expect(params.cluster).to.equal('cluster-yo7');
+        expect(params.serviceName).to.equal('service-yo7');
 
         cb(null, {
           taskArns: [
@@ -234,8 +246,12 @@ describe('Service', function() {
         });
       });
 
+      AWS.mock('ECS', 'describeServices', (params, cb) => {
+        cb(null, fixtures['newDeployment']);
+      });
+
       AWS.mock('ECS', 'describeTasks', function (params, cb) {
-        expect(params.cluster).to.equal('cluster-yo');
+        expect(params.cluster).to.equal('cluster-yo7');
 
         cb(null, {
           tasks: [
@@ -245,7 +261,7 @@ describe('Service', function() {
         });
       });
 
-      var service = new Service({clusterArn: 'cluster-yo', serviceName: 'service-yo'});
+      var service = new Service({clusterArn: 'cluster-yo7', serviceName: 'service-yo7'});
       service._tasks((err, tasks) => {
         expect(tasks.length).to.equal(2);
         expect(tasks[0].taskArn).to.equal("arn:task:1");
@@ -256,9 +272,13 @@ describe('Service', function() {
     it('should handle no tasks in a service', function(done) {
       serviceTasks.restore();
 
+      AWS.mock('ECS', 'describeServices', (params, cb) => {
+        cb(null, fixtures['newDeployment']);
+      });
+
       AWS.mock('ECS', 'listTasks', function (params, cb) {
-        expect(params.cluster).to.equal('cluster-yo');
-        expect(params.serviceName).to.equal('service-yo');
+        expect(params.cluster).to.equal('cluster-yo8');
+        expect(params.serviceName).to.equal('service-yo8');
 
         cb(null, {
           taskArns: []
@@ -270,7 +290,7 @@ describe('Service', function() {
         expect(true).to.equal(false);
       });
 
-      var service = new Service({clusterArn: 'cluster-yo', serviceName: 'service-yo'});
+      var service = new Service({clusterArn: 'cluster-yo8', serviceName: 'service-yo8'});
       service._tasks((err, tasks) => {
         expect(tasks.length).to.equal(0);
         done();
@@ -345,7 +365,7 @@ describe('Service', function() {
         cb(null, fixtures['newDeployment']);
       });
 
-      var service = new Service({clusterArn: 'cluster-yo', serviceName: 'service-yo'});
+      var service = new Service({clusterArn: 'cluster-yo9', serviceName: 'service-yo9'});
 
       service.on('updated', function() {
         expect(service.isTaskHealthy('arn::task:1')).to.equal(false);

--- a/test/service.js
+++ b/test/service.js
@@ -53,13 +53,13 @@ describe('Service', function() {
   describe('Constructor', function() {
     it('should return call describeServices with correct params', function(done) {
       AWS.mock('ECS', 'describeServices', function (params, cb){
-        expect(params.cluster).to.equal('cluster-yo0');
-        expect(params.services).to.eql(['service-yo0']);
+        expect(params.cluster).to.equal('cluster-0');
+        expect(params.services).to.eql(['service-0']);
         service.destroy();
         done();
       });
 
-      var service = new Service({clusterArn: 'cluster-yo0', serviceName: 'service-yo0'});
+      var service = new Service({clusterArn: 'cluster-0', serviceName: 'service-0'});
     });
 
     it('should return call _clusterContainerInstances', function(done) {
@@ -67,7 +67,7 @@ describe('Service', function() {
         cb(null, fixtures['newDeployment']);
       });
 
-      var service = new Service({clusterArn: 'cluster-yo1', serviceName: 'service-yo1'});
+      var service = new Service({clusterArn: 'cluster-1', serviceName: 'service-1'});
       service.on('updated', () => {
         expect(service.clusterContainerInstances).to.eql(['instance']);
         done();
@@ -81,7 +81,7 @@ describe('Service', function() {
         cb(null, fixtures['newDeployment']);
       });
 
-      var service = new Service({clusterArn: 'cluster-yo2', serviceName: 'service-yo2'});
+      var service = new Service({clusterArn: 'cluster-2', serviceName: 'service-2'});
       var events = service._pluckEventsSince(fixtures['newDeployment']['services'][0]['events'], 1494960755);
       service.destroy();
 
@@ -98,7 +98,7 @@ describe('Service', function() {
         cb(null, { tasks: [1,2,3,4] });
       });
 
-      var service = new Service({clusterArn: 'cluster-yo3', serviceName: 'service-yo3'});
+      var service = new Service({clusterArn: 'cluster-3', serviceName: 'service-3'});
 
       service.on('event', (event) => {
         expect(event.raw.id).to.equal("e1e75594-b9c9-4c32-bb90-89801bd89a62");
@@ -142,7 +142,7 @@ describe('Service', function() {
         cb(null, fixtures['newDeployment']);
       });
 
-      var service = new Service({clusterArn: 'cluster-yo4', serviceName: 'service-yo4'});
+      var service = new Service({clusterArn: 'cluster-4', serviceName: 'service-4'});
       service.on('updated', () => {
         expect(service.targets.length).to.equal(1);
         done();
@@ -158,7 +158,7 @@ describe('Service', function() {
         cb(null, fixtures['newDeployment']);
       });
 
-      var service = new Service({clusterArn: 'cluster-yo5', serviceName: 'service-yo5'});
+      var service = new Service({clusterArn: 'cluster-5', serviceName: 'service-5'});
       service.on('updated', () => {
         service.targets = [
           {
@@ -196,7 +196,7 @@ describe('Service', function() {
       containerInstanceStub.restore();
 
       AWS.mock('ECS', 'listContainerInstances', function (params, cb) {
-        expect(params.cluster).to.equal('cluster-yo6');
+        expect(params.cluster).to.equal('cluster-6');
 
         cb(null, {
           containerInstanceArns: [
@@ -207,7 +207,7 @@ describe('Service', function() {
       });
 
       AWS.mock('ECS', 'describeContainerInstances', function (params, cb) {
-        expect(params.cluster).to.equal('cluster-yo6');
+        expect(params.cluster).to.equal('cluster-6');
 
         cb(null, {
           containerInstances: [
@@ -221,7 +221,7 @@ describe('Service', function() {
         cb(null, fixtures['newDeployment']);
       });
 
-      var service = new Service({clusterArn: 'cluster-yo6', serviceName: 'service-yo6'});
+      var service = new Service({clusterArn: 'cluster-6', serviceName: 'service-6'});
       service._clusterContainerInstances((err, containerInstances) => {
         expect(containerInstances.length).to.equal(2);
         expect(containerInstances[0].ec2InstanceId).to.equal('i-1');
@@ -235,8 +235,8 @@ describe('Service', function() {
       serviceTasks.restore();
 
       AWS.mock('ECS', 'listTasks', function (params, cb) {
-        expect(params.cluster).to.equal('cluster-yo7');
-        expect(params.serviceName).to.equal('service-yo7');
+        expect(params.cluster).to.equal('cluster-7');
+        expect(params.serviceName).to.equal('service-7');
 
         cb(null, {
           taskArns: [
@@ -251,7 +251,7 @@ describe('Service', function() {
       });
 
       AWS.mock('ECS', 'describeTasks', function (params, cb) {
-        expect(params.cluster).to.equal('cluster-yo7');
+        expect(params.cluster).to.equal('cluster-7');
 
         cb(null, {
           tasks: [
@@ -261,7 +261,7 @@ describe('Service', function() {
         });
       });
 
-      var service = new Service({clusterArn: 'cluster-yo7', serviceName: 'service-yo7'});
+      var service = new Service({clusterArn: 'cluster-7', serviceName: 'service-7'});
       service._tasks((err, tasks) => {
         expect(tasks.length).to.equal(2);
         expect(tasks[0].taskArn).to.equal("arn:task:1");
@@ -277,8 +277,8 @@ describe('Service', function() {
       });
 
       AWS.mock('ECS', 'listTasks', function (params, cb) {
-        expect(params.cluster).to.equal('cluster-yo8');
-        expect(params.serviceName).to.equal('service-yo8');
+        expect(params.cluster).to.equal('cluster-8');
+        expect(params.serviceName).to.equal('service-8');
 
         cb(null, {
           taskArns: []
@@ -290,7 +290,7 @@ describe('Service', function() {
         expect(true).to.equal(false);
       });
 
-      var service = new Service({clusterArn: 'cluster-yo8', serviceName: 'service-yo8'});
+      var service = new Service({clusterArn: 'cluster-8', serviceName: 'service-8'});
       service._tasks((err, tasks) => {
         expect(tasks.length).to.equal(0);
         done();
@@ -365,7 +365,7 @@ describe('Service', function() {
         cb(null, fixtures['newDeployment']);
       });
 
-      var service = new Service({clusterArn: 'cluster-yo9', serviceName: 'service-yo9'});
+      var service = new Service({clusterArn: 'cluster-9', serviceName: 'service-9'});
 
       service.on('updated', function() {
         expect(service.isTaskHealthy('arn::task:1')).to.equal(false);
@@ -381,7 +381,7 @@ describe('Service', function() {
         {
           Target: {
             Ip: "192.0.2.1",
-            Port: 25001
+            Port: 8443
           },
           TargetHealth: {
             State: "healthy"
@@ -390,59 +390,68 @@ describe('Service', function() {
         {
           Target: {
             Ip: "192.0.2.2",
-            Port: 25002
+            Port: 8443
           },
           TargetHealth: {
-            State: "healthy"
-          }
-        },
-        {
-          Target: {
-            Ip: "192.0.2.3",
-            Port: 25003
-          },
-          TargetHealth: {
-            State: "healthy"
+            State: "unhealthy"
           }
         }
       ]);
 
       setServiceDependencyFixture('tasks', [
         {
-          taskArn: 'arn::fargate-task:1',
+          taskArn: 'arn:aws:ecs:us-east-1:12345789012:task/mycluster/abcdefgh',
           containers: [
             {
-              name: 'app',
-              networkBindings: [
+                "name": "app"
+            }
+          ],
+          attachments: [
+            {
+              'type': 'ElasticNetworkInterface',
+              'details': [
                 {
-                  hostPort: 25001
-                }
+                  'name': 'privateIPv4Address',
+                  'value': '192.0.2.1'
+                },
               ]
             }
           ]
         },
         {
-          taskArn: 'arn::fargate-task:1',
+          taskArn: 'arn:aws:ecs:us-east-1:12345789012:task/mycluster/bcdefghi',
           containers: [
             {
-              name: 'app',
-              networkBindings: [
+                "name": "app"
+            }
+          ],
+          attachments: [
+            {
+              'type': 'ElasticNetworkInterface',
+              'details': [
                 {
-                  hostPort: 25002
-                }
+                  'name': 'privateIPv4Address',
+                  'value': '192.0.2.2'
+                },
               ]
             }
           ]
         },
         {
-          taskArn: 'arn::fargate-task:1',
+          taskArn: 'arn:aws:ecs:us-east-1:12345789012:task/mycluster/cdefghij',
           containers: [
             {
-              name: 'app',
-              networkBindings: [
+                "name": "app"
+            }
+          ],
+          attachments: [
+            {
+              'type': 'ElasticNetworkInterface',
+              'details': [
                 {
-                  hostPort: 25003
-                }
+                  'name': 'privateIPv4Address',
+                  'value': '192.0.2.3'
+                },
               ]
             }
           ]
@@ -458,7 +467,9 @@ describe('Service', function() {
       var service = new Service({clusterArn: 'arn:aws:ecs:us-east-1:12345789012:cluster/mycluster', serviceName: 'my-test-application'});
 
       service.on('updated', function() {
-        expect(service.isTaskHealthy('arn::fargate-task:1')).to.equal(true);
+        expect(service.isTaskHealthy('arn:aws:ecs:us-east-1:12345789012:task/mycluster/abcdefgh')).to.equal(true);
+        expect(service.isTaskHealthy('arn:aws:ecs:us-east-1:12345789012:task/mycluster/bcdefghi')).to.equal(false);
+        expect(service.isTaskHealthy('arn:aws:ecs:us-east-1:12345789012:task/mycluster/cdefghij')).to.equal(false);
         done();
       });
     });


### PR DESCRIPTION
Fargate support was missing - since there are no container instances backing Fargate tasks, any attempt to check the health of the container instance in the target group would fail. Instead, Fargate tasks have their own awsvpc networking and are attached to the target group by IP directly. Thus, checking the health of the target group entries is sufficient for understanding the health of the tasks themselves.

Have now added tests as well, although they are so heavily mocked and supported by fixtures that they are a bit unsatisfying. Any feedback welcome.

Closes #5 