### PR TITLE
Bump to 0.2.5-rc1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
-  "name": "ecs-deployment-monitor",
-  "version": "0.2.5-rc0",
+  "name": "@bugcrowd/ecs-deployment-monitor",
+  "version": "0.2.5-rc1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.2.5-rc0",
+      "name": "@bugcrowd/ecs-deployment-monitor",
+      "version": "0.2.5-rc1",
       "license": "MIT",
       "dependencies": {
         "async": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugcrowd/ecs-deployment-monitor",
-  "version": "0.2.5-rc0",
+  "version": "0.2.5-rc1",
   "description": "Monitor an ECS Deployment",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I've still managed to make a mess of the NPM package versions, so I need to tag another release. It does include the lodash upgrade though.