### PR TITLE
bugfix: exit codes being emitted but not returned.

### DIFF
--- a/bin/ecs-deployment-monitor
+++ b/bin/ecs-deployment-monitor
@@ -20,4 +20,5 @@ var deployment = monitor({
 deployment.on('error', (err) => {
   throw err
 });
-// deployment.on('exitCode', (exitCode) => process.exit(exitCode));
+
+deployment.on('exitCode', (exitCode) => process.exit(exitCode));


### PR DESCRIPTION
Hey, looks like code that exits with the emitted status codes was removed [here](https://github.com/bugcrowd/ecs-deployment-monitor/commit/6e36777d120587f683135cad6044cb692f4138bf).

cc/ @liath @ohookins