### PR TITLE
[CHORE] Remove use of requirize

### DIFF
--- a/lib/evaluators/index.js
+++ b/lib/evaluators/index.js
@@ -1,1 +1,9 @@
-module.exports = require('requirize')(__dirname, 'classify');
+module.exports = {
+  Created: require('./created'),
+  Draining: require('./draining'),
+  Live: require('./live'),
+  Steady: require('./steady'),
+  TasksFailed: require('./tasks-failed'),
+  TasksStarted: require('./tasks-started'),
+  Usurped: require('./usurped'),
+};

--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -1,1 +1,6 @@
-module.exports = require('requirize')(__dirname, 'classify');
+module.exports = {
+  Event: require('./event'),
+  SteadyEvent: require('./steady-event'),
+  TasksStartedEvent: require('./tasks-started-event'),
+  TasksStoppedEvent: require('./tasks-stopped-event'),
+};

--- a/lib/renderer/states/index.js
+++ b/lib/renderer/states/index.js
@@ -1,1 +1,10 @@
-module.exports = require('requirize')(__dirname, 'classify');
+module.exports = {
+  Created: require('./created'),
+  Draining: require('./draining'),
+  Live: require('./live'),
+  NotFound: require('./not-found'),
+  Steady: require('./steady'),
+  TasksFailed: require('./tasks-failed'),
+  TasksStarted: require('./tasks-started'),
+  Usurped: require('./usurped'),
+};

--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -1,1 +1,3 @@
-module.exports = require('requirize')(__dirname);
+module.exports = {
+  tasks: require('./tasks'),
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bugcrowd/ecs-deployment-monitor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bugcrowd/ecs-deployment-monitor",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ecs": "^3.454.0",
@@ -16,7 +16,6 @@
         "indent": "0.0.2",
         "inflection": "^1.12.0",
         "moment": "^2.24.0",
-        "requirize": "^0.2.0",
         "winston": "^3.2.1",
         "yargs": "^15.0.2"
       },
@@ -4318,14 +4317,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
-    "node_modules/requirize": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/requirize/-/requirize-0.2.0.tgz",
-      "integrity": "sha512-1NhHKj5eooy/flVnRt1QVfnYsyjZxEhViPp2rcpQMwis6bA+Ni6+Vy4p/yA0KLrDbkTuzFsPNQYEOUB1j80QcA==",
-      "dependencies": {
-        "underscore.string": "^3.3.5"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4534,11 +4525,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -4774,18 +4760,6 @@
       "dev": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/underscore.string": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
-      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
-      "dependencies": {
-        "sprintf-js": "^1.0.3",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -8492,14 +8466,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
-    "requirize": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/requirize/-/requirize-0.2.0.tgz",
-      "integrity": "sha512-1NhHKj5eooy/flVnRt1QVfnYsyjZxEhViPp2rcpQMwis6bA+Ni6+Vy4p/yA0KLrDbkTuzFsPNQYEOUB1j80QcA==",
-      "requires": {
-        "underscore.string": "^3.3.5"
-      }
-    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -8675,11 +8641,6 @@
         "signal-exit": "^3.0.2",
         "which": "^2.0.1"
       }
-    },
-    "sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -8865,15 +8826,6 @@
       "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "underscore.string": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
-      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
-      "requires": {
-        "sprintf-js": "^1.0.3",
-        "util-deprecate": "^1.0.2"
       }
     },
     "update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugcrowd/ecs-deployment-monitor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Monitor an ECS Deployment",
   "main": "index.js",
   "scripts": {
@@ -31,7 +31,6 @@
     "indent": "0.0.2",
     "inflection": "^1.12.0",
     "moment": "^2.24.0",
-    "requirize": "^0.2.0",
     "winston": "^3.2.1",
     "yargs": "^15.0.2"
   }

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,1 +1,6 @@
-module.exports = require('requirize')(__dirname);
+module.exports = {
+  fargateDeployment: require('./fargate-deployment.json'),
+  newDeployment: require('./new-deployment.json'),
+  tasksStartedDeployment: require('./tasks-started-deployment.json'),
+  usurpedDeployment: require('./usurped-deployment.json'),
+};


### PR DESCRIPTION
Was running into very weird errors within Github Actions when running a deployment, and it seems like the core problem is this package's use of [requirize](https://www.npmjs.com/package/requirize), and the need to bundle packages when using them as a custom Action.

In short, bundling properly rewrites `require` invocations, but `requirize` will actually [walk the directory](https://github.com/coen-hyde/requirize/blob/master/index.js#L12) mentioned and dynamically require files at runtime. When the libraries in question are bundled, this is not going to work, and it will not find any of the paths, generate an empty object and return that for the required code. Then things start failing mysteriously.

So while it's a bit more laborious to require each individual file, it solves this problem and that's the key thing. I'm not aware of a "modern Javascript" way of doing this nicely but I'm all ears for an alternative.