### PR TITLE
Mark repository as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## ⚠️ Deprecated
+
+This tool is no longer used internally at Bugcrowd and will no longer be maintained. This repository will be archived.
+
+Thank you to everyone who has contributed code to this project over the years — your efforts are appreciated!
+
+---
+
 ECS Deployment Monitor
 ==============================
 


### PR DESCRIPTION
This adds a deprecation notice to the top of the README indicating that this tool is no longer used internally at Bugcrowd, will no longer be maintained, and the repository will be archived. Thanks past contributors for their efforts.